### PR TITLE
Fixed wrong filenames in hisat manifest

### DIFF
--- a/xfer/hisat/hisat.manifest
+++ b/xfer/hisat/hisat.manifest
@@ -12,8 +12,8 @@ https://cloud.biohpc.swmed.edu/index.php/s/grch37_tran/download hisat/grch37_tra
 https://cloud.biohpc.swmed.edu/index.php/s/grch37_snp_tran/download hisat/grch37_snptran.tar.gz
 https://cloud.biohpc.swmed.edu/index.php/s/hg19/download hisat/hg19_genome.tar.gz
 https://cloud.biohpc.swmed.edu/index.php/s/grcm38/download hisat/grcm38_genome.tar.gz
-https://cloud.biohpc.swmed.edu/index.php/s/grcm38/download hisat/grcm38_snp.tar.gz
-https://cloud.biohpc.swmed.edu/index.php/s/grcm38_snp/download hisat/grcm38_tran.tar.gz
+https://cloud.biohpc.swmed.edu/index.php/s/grcm38_snp/download hisat/grcm38_snp.tar.gz
+https://cloud.biohpc.swmed.edu/index.php/s/grcm38_tran/download hisat/grcm38_tran.tar.gz
 https://cloud.biohpc.swmed.edu/index.php/s/grcm38_snp_tran/download hisat/grcm38_snptran.tar.gz
 https://cloud.biohpc.swmed.edu/index.php/s/mm10/download hisat/mm10_genome.tar.gz
 https://cloud.biohpc.swmed.edu/index.php/s/rn6/download hisat/rn6_genome.tar.gz


### PR DESCRIPTION
There are errors in the hisat manifest file, so some files are mislabeled.