### PR TITLE
Update PrackenDB information in k2.md

### DIFF
--- a/docs/k2.md
+++ b/docs/k2.md
@@ -173,13 +173,13 @@ MicrobialDB   | archaea, bacteria, viral, human, UniVec_Core, Eukaryotic pathoge
 
 # Pracken index
 
-As of January 2026, a new Kraken 2 database is available, tentatively called PrackenDB. This contains all NCBI reference assemblies (Genbank and RefSeq) of bacteria, archaea, protists, and fungi as of October 7, 2025. Also includes the human genome, RefSeq viral genomes, and UniVec Core. A key difference from other Kraken DBs is that it has only a single reference genome per species (with a couple of exceptions such as normal and pathogenic E. coli), which is useful for methods that count k-mers per species.
+As of January 2026, a new Kraken 2 database is available, tentatively called PrackenDB. This contains all NCBI [reference](https://support.nlm.nih.gov/kbArticle/?pn=KA-03578) assemblies of bacteria, archaea, protists, and fungi as of October 7, 2025. Also includes the human genome, RefSeq viral genomes, and UniVec Core. A key difference from other Kraken DBs is that it has only a single reference genome per species (with a couple of exceptions such as normal and pathogenic E. coli), which is useful for methods that count k-mers per species.
 
 Date       | Archive size (GB) |                         HTTPS URL | 
 ---------- |-------------------|-----------------------------------|
 Oct 2025   | 351.6 GB          | [.tar.gz][pracken202510_url]               |
 
-[pracken202510_url]: https://genome-idx.s3.amazonaws.com/kraken/k2_nt_20230502_missing_bracken150.tar.gz
+[pracken202510_url]: https://genome-idx.s3.amazonaws.com/kraken/k2_NCBI_reference_20251007.tar.gz
 
 # Older Kraken 2 / Bracken Refseq indexes
 


### PR DESCRIPTION
Updated PrackenDB description to include a link for what NCBI "reference" assemblies are and corrected the download URL. (https://github.com/DerrickWood/kraken2/issues/1005)

And thanks for hosting!