### PR TITLE
[codex] Add Index Zone usage dashboard and homepage stats

### DIFF
--- a/docs/_data/usage_highlights.json
+++ b/docs/_data/usage_highlights.json
@@ -1,15 +1,16 @@
 {
-  "generated_at": "2026-05-24T15:11:31+00:00",
+  "generated_at": "2026-05-24T16:26:24+00:00",
   "period": {
     "start": "2026-05-01",
     "end": "2026-05-24",
     "label": "May 1 through May 23, 2026"
   },
   "first_known_log_date": "2020-06-15",
-  "storage_timestamp": "2026-05-22T11:11:00-04:00",
+  "storage_timestamp": "2026-05-22T12:26:00-04:00",
   "metrics": {
     "egress_gb": 167608.3841511367,
     "public_egress_gb": 165901.8753608847,
+    "weekly_egress_gb": 51011.247350345955,
     "requests": 609541.0,
     "unblended_cost_usd": 8589.723126415498,
     "storage_bytes": 28096623437871.0,
@@ -36,6 +37,20 @@
       "label": "S3 requests this period",
       "value": "610K",
       "detail": "Cost Explorer request classes for the same period."
+    }
+  ],
+  "site_cards": [
+    {
+      "label": "Indexed data stored",
+      "value": "28.1 TB"
+    },
+    {
+      "label": "Files available",
+      "value": "4,631"
+    },
+    {
+      "label": "Data served per week",
+      "value": "51.0 TB"
     }
   ]
 }

--- a/docs/_data/usage_highlights.json
+++ b/docs/_data/usage_highlights.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T16:32:41+00:00",
+  "generated_at": "2026-05-24T16:34:53+00:00",
   "updated_label": "May 24, 2026",
   "period": {
     "start": "2026-05-01",
@@ -7,7 +7,7 @@
     "label": "May 1 through May 23, 2026"
   },
   "first_known_log_date": "2020-06-15",
-  "storage_timestamp": "2026-05-22T12:32:00-04:00",
+  "storage_timestamp": "2026-05-22T12:34:00-04:00",
   "metrics": {
     "egress_gb": 167608.3841511367,
     "public_egress_gb": 165901.8753608847,
@@ -56,7 +56,8 @@
     },
     {
       "label": "AWS charges per week",
-      "value": "~$2.6K"
+      "value": "~$2.6K",
+      "note": "Thank you, AWS!"
     }
   ]
 }

--- a/docs/_data/usage_highlights.json
+++ b/docs/_data/usage_highlights.json
@@ -21,7 +21,7 @@
   },
   "cards": [
     {
-      "label": "Indexed data stored",
+      "label": "Data stored",
       "value": "28.1 TB",
       "detail": "Current S3 storage across 4,631 objects."
     },
@@ -43,7 +43,7 @@
   ],
   "site_cards": [
     {
-      "label": "Indexed data stored",
+      "label": "Data stored",
       "value": "28.1 TB"
     },
     {
@@ -51,11 +51,11 @@
       "value": "4,631"
     },
     {
-      "label": "Data served per week",
+      "label": "Served / week",
       "value": "~51.0 TB"
     },
     {
-      "label": "AWS charges per week",
+      "label": "AWS charges / week",
       "value": "~$2.6K",
       "note": "Thank you, AWS!"
     }

--- a/docs/_data/usage_highlights.json
+++ b/docs/_data/usage_highlights.json
@@ -1,16 +1,18 @@
 {
-  "generated_at": "2026-05-24T16:26:24+00:00",
+  "generated_at": "2026-05-24T16:30:47+00:00",
+  "updated_label": "May 24, 2026",
   "period": {
     "start": "2026-05-01",
     "end": "2026-05-24",
     "label": "May 1 through May 23, 2026"
   },
   "first_known_log_date": "2020-06-15",
-  "storage_timestamp": "2026-05-22T12:26:00-04:00",
+  "storage_timestamp": "2026-05-22T12:30:00-04:00",
   "metrics": {
     "egress_gb": 167608.3841511367,
     "public_egress_gb": 165901.8753608847,
     "weekly_egress_gb": 51011.247350345955,
+    "weekly_unblended_cost_usd": 2614.2635602134123,
     "requests": 609541.0,
     "unblended_cost_usd": 8589.723126415498,
     "storage_bytes": 28096623437871.0,
@@ -51,6 +53,10 @@
     {
       "label": "Data served per week",
       "value": "51.0 TB"
+    },
+    {
+      "label": "AWS charges per week",
+      "value": "$2.6K"
     }
   ]
 }

--- a/docs/_data/usage_highlights.json
+++ b/docs/_data/usage_highlights.json
@@ -1,0 +1,41 @@
+{
+  "generated_at": "2026-05-24T15:11:31+00:00",
+  "period": {
+    "start": "2026-05-01",
+    "end": "2026-05-24",
+    "label": "May 1 through May 23, 2026"
+  },
+  "first_known_log_date": "2020-06-15",
+  "storage_timestamp": "2026-05-22T11:11:00-04:00",
+  "metrics": {
+    "egress_gb": 167608.3841511367,
+    "public_egress_gb": 165901.8753608847,
+    "requests": 609541.0,
+    "unblended_cost_usd": 8589.723126415498,
+    "storage_bytes": 28096623437871.0,
+    "storage_tb_decimal": 28.096623437871,
+    "objects": 4631.0
+  },
+  "cards": [
+    {
+      "label": "Indexed data stored",
+      "value": "28.1 TB",
+      "detail": "Current S3 storage across 4,631 objects."
+    },
+    {
+      "label": "Objects available",
+      "value": "4,631",
+      "detail": "Public files, archives, indexes, checksums, and reports in genome-idx."
+    },
+    {
+      "label": "Data served this period",
+      "value": "167.6 TB",
+      "detail": "S3 transfer out from May 1 through May 23, 2026."
+    },
+    {
+      "label": "S3 requests this period",
+      "value": "610K",
+      "detail": "Cost Explorer request classes for the same period."
+    }
+  ]
+}

--- a/docs/_data/usage_highlights.json
+++ b/docs/_data/usage_highlights.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T16:30:47+00:00",
+  "generated_at": "2026-05-24T16:32:41+00:00",
   "updated_label": "May 24, 2026",
   "period": {
     "start": "2026-05-01",
@@ -7,7 +7,7 @@
     "label": "May 1 through May 23, 2026"
   },
   "first_known_log_date": "2020-06-15",
-  "storage_timestamp": "2026-05-22T12:30:00-04:00",
+  "storage_timestamp": "2026-05-22T12:32:00-04:00",
   "metrics": {
     "egress_gb": 167608.3841511367,
     "public_egress_gb": 165901.8753608847,
@@ -52,11 +52,11 @@
     },
     {
       "label": "Data served per week",
-      "value": "51.0 TB"
+      "value": "~51.0 TB"
     },
     {
       "label": "AWS charges per week",
-      "value": "$2.6K"
+      "value": "~$2.6K"
     }
   ]
 }

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -436,6 +436,11 @@ hr {
   font-size: 0.88rem;
   font-weight: 600;
 }
+.home-usage-updated {
+  margin: 0.85rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
 .home-bucket {
   margin: 0;
   font-size: 0.95rem;

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -407,6 +407,35 @@ hr {
   margin: 0 0 0.75rem;
   max-width: var(--content-max);
 }
+.home-usage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+.home-usage-card {
+  min-height: 5.75rem;
+  padding: 0.85rem 0.95rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--accent);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+.home-usage-value {
+  display: block;
+  font-size: 1.55rem;
+  line-height: 1.1;
+  color: var(--text-heading);
+  font-weight: 700;
+}
+.home-usage-label {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--text-heading);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
 .home-bucket {
   margin: 0;
   font-size: 0.95rem;
@@ -416,70 +445,6 @@ hr {
   padding: 0.15rem 0.45rem;
   border-radius: 4px;
   border: 1px solid var(--border);
-}
-.usage-highlights {
-  margin: 0 0 2rem;
-  padding: 1rem 0 0;
-  border-top: 1px solid var(--border);
-}
-.usage-highlights-header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 0.85rem;
-}
-.usage-highlights-header h2 {
-  margin: 0;
-  font-size: 1rem;
-}
-.usage-highlights-header p {
-  margin: 0;
-  max-width: 34rem;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-  text-align: right;
-}
-.usage-highlight-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
-  gap: 0.75rem;
-}
-.usage-highlight {
-  min-height: 8.25rem;
-  padding: 0.9rem 1rem;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-left: 4px solid var(--accent);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-}
-.usage-highlight-value {
-  display: block;
-  font-size: 1.65rem;
-  line-height: 1.1;
-  color: var(--text-heading);
-  font-weight: 700;
-}
-.usage-highlight-label {
-  display: block;
-  margin-top: 0.35rem;
-  color: var(--text-heading);
-  font-size: 0.88rem;
-  font-weight: 600;
-}
-.usage-highlight-detail {
-  display: block;
-  margin-top: 0.35rem;
-  color: var(--text-muted);
-  font-size: 0.8rem;
-  line-height: 1.35;
-}
-.usage-highlight-note {
-  margin: 0.65rem 0 0;
-  max-width: var(--content-max);
-  color: var(--text-muted);
-  font-size: 0.82rem;
 }
 .tool-grid-heading {
   font-size: 1rem;
@@ -613,13 +578,6 @@ body.layout-full {
     border-width: 1px 0;
     padding: 1.25rem 0;
     margin: 0 0 1.25rem;
-  }
-  .usage-highlights-header {
-    display: block;
-  }
-  .usage-highlights-header p {
-    margin-top: 0.35rem;
-    text-align: left;
   }
 }
 @media print, screen and (max-width: 720px) {

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -436,6 +436,12 @@ hr {
   font-size: 0.88rem;
   font-weight: 600;
 }
+.home-usage-note {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--text-muted);
+  font-size: 0.76rem;
+}
 .home-usage-updated {
   margin: 0.85rem 0 0;
   color: var(--text-muted);

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -417,6 +417,70 @@ hr {
   border-radius: 4px;
   border: 1px solid var(--border);
 }
+.usage-highlights {
+  margin: 0 0 2rem;
+  padding: 1rem 0 0;
+  border-top: 1px solid var(--border);
+}
+.usage-highlights-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.85rem;
+}
+.usage-highlights-header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+.usage-highlights-header p {
+  margin: 0;
+  max-width: 34rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-align: right;
+}
+.usage-highlight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 0.75rem;
+}
+.usage-highlight {
+  min-height: 8.25rem;
+  padding: 0.9rem 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--accent);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+.usage-highlight-value {
+  display: block;
+  font-size: 1.65rem;
+  line-height: 1.1;
+  color: var(--text-heading);
+  font-weight: 700;
+}
+.usage-highlight-label {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--text-heading);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+.usage-highlight-detail {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+.usage-highlight-note {
+  margin: 0.65rem 0 0;
+  max-width: var(--content-max);
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
 .tool-grid-heading {
   font-size: 1rem;
   font-weight: 600;
@@ -549,6 +613,13 @@ body.layout-full {
     border-width: 1px 0;
     padding: 1.25rem 0;
     margin: 0 0 1.25rem;
+  }
+  .usage-highlights-header {
+    display: block;
+  }
+  .usage-highlights-header p {
+    margin-top: 0.35rem;
+    text-align: left;
   }
 }
 @media print, screen and (max-width: 720px) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,9 @@
     {% endfor %}
   </div>
   {% endif %}
+  {% if usage.updated_label %}
+  <p class="home-usage-updated">Stats updated {{ usage.updated_label }}.</p>
+  {% endif %}
 </div>
 
 <h2 class="tool-grid-heading">Browse by tool</h2>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,26 @@
   </p>
 </div>
 
+{% assign usage = site.data.usage_highlights %}
+{% if usage.cards %}
+<section class="usage-highlights" aria-labelledby="usage-highlights-heading">
+  <div class="usage-highlights-header">
+    <h2 id="usage-highlights-heading">Usage snapshot</h2>
+    <p>Measured from AWS Cost Explorer and CloudWatch. Current-month figures cover {{ usage.period.label }}.</p>
+  </div>
+  <div class="usage-highlight-grid">
+    {% for card in usage.cards %}
+    <div class="usage-highlight">
+      <span class="usage-highlight-value">{{ card.value }}</span>
+      <span class="usage-highlight-label">{{ card.label }}</span>
+      <span class="usage-highlight-detail">{{ card.detail }}</span>
+    </div>
+    {% endfor %}
+  </div>
+  <p class="usage-highlight-note">Server access logs are available back to {{ usage.first_known_log_date }} for more detailed file-level analysis.</p>
+</section>
+{% endif %}
+
 <h2 class="tool-grid-heading">Browse by tool</h2>
 <div class="tool-grid">
 {% for nav in site.navigation %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
     <div class="home-usage-card">
       <span class="home-usage-value">{{ card.value }}</span>
       <span class="home-usage-label">{{ card.label }}</span>
+      {% if card.note %}<span class="home-usage-note">{{ card.note }}</span>{% endif %}
     </div>
     {% endfor %}
   </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,28 +1,19 @@
 <div class="home-hero">
+  {% assign usage = site.data.usage_highlights %}
   <p class="home-lead">
     Thanks to the <a href="https://aws.amazon.com/opendata/public-datasets/">AWS Open Data Sponsorship Program</a>, indexes are freely available via <strong>HTTPS</strong> and <strong>S3</strong>.
   </p>
-</div>
-
-{% assign usage = site.data.usage_highlights %}
-{% if usage.cards %}
-<section class="usage-highlights" aria-labelledby="usage-highlights-heading">
-  <div class="usage-highlights-header">
-    <h2 id="usage-highlights-heading">Usage snapshot</h2>
-    <p>Measured from AWS Cost Explorer and CloudWatch. Current-month figures cover {{ usage.period.label }}.</p>
-  </div>
-  <div class="usage-highlight-grid">
-    {% for card in usage.cards %}
-    <div class="usage-highlight">
-      <span class="usage-highlight-value">{{ card.value }}</span>
-      <span class="usage-highlight-label">{{ card.label }}</span>
-      <span class="usage-highlight-detail">{{ card.detail }}</span>
+  {% if usage.site_cards %}
+  <div class="home-usage-grid">
+    {% for card in usage.site_cards %}
+    <div class="home-usage-card">
+      <span class="home-usage-value">{{ card.value }}</span>
+      <span class="home-usage-label">{{ card.label }}</span>
     </div>
     {% endfor %}
   </div>
-  <p class="usage-highlight-note">Server access logs are available back to {{ usage.first_known_log_date }} for more detailed file-level analysis.</p>
-</section>
-{% endif %}
+  {% endif %}
+</div>
 
 <h2 class="tool-grid-heading">Browse by tool</h2>
 <div class="tool-grid">

--- a/tools/usage/README.md
+++ b/tools/usage/README.md
@@ -95,3 +95,31 @@ python3 tools/usage/index_zone_usage.py storage --format csv
 
 This discovers available S3 storage metric dimensions for `genome-idx`, then
 reports the latest datapoint found within the last 14 days.
+
+## Snapshot for the explorer UI
+
+Build a single JSON file containing Cost Explorer rows, storage rows, and any
+cached log summaries:
+
+```bash
+python3 tools/usage/index_zone_usage.py snapshot \
+  --start 2026-05-01 \
+  --end 2026-05-24 \
+  --output /tmp/index-zone-usage-snapshot.json
+```
+
+Open `tools/usage/ui/index.html` in a browser and load the snapshot JSON.
+
+## Website highlights
+
+Build the small JSON file used by the Index Zone home page usage cards:
+
+```bash
+python3 tools/usage/index_zone_usage.py highlights \
+  --start 2026-05-01 \
+  --end 2026-05-24 \
+  --output docs/_data/usage_highlights.json
+```
+
+The committed snapshot should be refreshed deliberately; it is not updated by
+the site build.

--- a/tools/usage/README.md
+++ b/tools/usage/README.md
@@ -109,6 +109,10 @@ python3 tools/usage/index_zone_usage.py snapshot \
 ```
 
 Open `tools/usage/ui/index.html` in a browser and load the snapshot JSON.
+The static explorer can roll Cost Explorer transfer data and inferred downloads
+up by day, week, or month. It also includes a selectable top-files table that
+allocates approximate download cost by applying the snapshot's effective
+transfer-out and request rates to each file's inferred download traffic.
 
 ## Website highlights
 

--- a/tools/usage/index_zone_usage.py
+++ b/tools/usage/index_zone_usage.py
@@ -642,6 +642,10 @@ def end_minus_one(end: str) -> str:
     return (dt.date.fromisoformat(end) - dt.timedelta(days=1)).isoformat()
 
 
+def period_days(start: str, end: str) -> int:
+    return max(1, (dt.date.fromisoformat(end) - dt.date.fromisoformat(start)).days)
+
+
 def display_period(start: str, end: str) -> str:
     start_date = dt.date.fromisoformat(start)
     end_date = dt.date.fromisoformat(end_minus_one(end))
@@ -696,6 +700,7 @@ def build_highlights(
     unblended_cost = sum_metric(cost_rows, metric="UnblendedCost")
     bytes_total, objects, storage_timestamp = storage_totals(storage)
     storage_tb = bytes_total / 1_000_000_000_000
+    weekly_egress_gb = egress_gb / period_days(start, end) * 7
     period_label = display_period(start, end)
     cards = [
         {
@@ -719,6 +724,20 @@ def build_highlights(
             "detail": "Cost Explorer request classes for the same period.",
         },
     ]
+    site_cards = [
+        {
+            "label": "Indexed data stored",
+            "value": f"{storage_tb:.1f} TB",
+        },
+        {
+            "label": "Files available",
+            "value": compact_number(objects),
+        },
+        {
+            "label": "Data served per week",
+            "value": f"{weekly_egress_gb / 1000:.1f} TB",
+        },
+    ]
     return {
         "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
         "period": {"start": start, "end": end, "label": period_label},
@@ -727,6 +746,7 @@ def build_highlights(
         "metrics": {
             "egress_gb": egress_gb,
             "public_egress_gb": public_egress_gb,
+            "weekly_egress_gb": weekly_egress_gb,
             "requests": requests,
             "unblended_cost_usd": unblended_cost,
             "storage_bytes": bytes_total,
@@ -734,6 +754,7 @@ def build_highlights(
             "objects": objects,
         },
         "cards": cards,
+        "site_cards": site_cards,
     }
 
 

--- a/tools/usage/index_zone_usage.py
+++ b/tools/usage/index_zone_usage.py
@@ -13,6 +13,7 @@ import dataclasses
 import datetime as dt
 import hashlib
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -27,6 +28,7 @@ DEFAULT_BUCKET = "genome-idx"
 DEFAULT_LOG_BUCKET = "genome-idx-logs"
 DEFAULT_REGION = "us-east-1"
 DEFAULT_CACHE_DIR = Path(".usage-cache") / "s3-access-logs"
+FIRST_KNOWN_LOG_DATE = "2020-06-15"
 
 S3_LOG_RE = re.compile(
     r"^(?P<owner>\S+) "
@@ -226,6 +228,16 @@ def write_rows(
         writer = csv.DictWriter(stream, fieldnames=headers)
         writer.writeheader()
         writer.writerows(rows)
+    finally:
+        if output:
+            stream.close()
+
+
+def write_json_document(document: Mapping[str, Any], output: str | None) -> None:
+    stream = open(output, "w") if output else sys.stdout
+    try:
+        json.dump(document, stream, indent=2, default=str)
+        stream.write("\n")
     finally:
         if output:
             stream.close()
@@ -580,6 +592,226 @@ def storage_rows(args: argparse.Namespace) -> list[dict[str, Any]]:
     return rows
 
 
+def numeric(value: Any) -> float:
+    if value in (None, ""):
+        return 0.0
+    return float(value)
+
+
+def sum_metric(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    metric: str,
+    unit: str | None = None,
+    group_suffix: str | None = None,
+    group_prefix: str | None = None,
+    group_exact: str | None = None,
+) -> float:
+    total = 0.0
+    for row in rows:
+        group = str(row.get("group", ""))
+        if row.get("metric") != metric:
+            continue
+        if unit and row.get("unit") != unit:
+            continue
+        if group_suffix and not group.endswith(group_suffix):
+            continue
+        if group_prefix and not group.startswith(group_prefix):
+            continue
+        if group_exact and group != group_exact:
+            continue
+        total += numeric(row.get("amount"))
+    return total
+
+
+def compact_number(value: float) -> str:
+    if value >= 1_000_000_000:
+        return f"{value / 1_000_000_000:.1f}B"
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f}M"
+    if value >= 10_000:
+        return f"{value / 1_000:.0f}K"
+    if value >= 1_000:
+        return f"{value:,.0f}"
+    if math.isclose(value, round(value)):
+        return f"{value:.0f}"
+    return f"{value:.1f}"
+
+
+def end_minus_one(end: str) -> str:
+    return (dt.date.fromisoformat(end) - dt.timedelta(days=1)).isoformat()
+
+
+def display_period(start: str, end: str) -> str:
+    start_date = dt.date.fromisoformat(start)
+    end_date = dt.date.fromisoformat(end_minus_one(end))
+    start_month = start_date.strftime("%B")
+    end_month = end_date.strftime("%B")
+    if start_date.year == end_date.year and start_date.month == end_date.month:
+        return f"{start_month} {start_date.day} through {end_month} {end_date.day}, {end_date.year}"
+    if start_date.year == end_date.year:
+        return f"{start_month} {start_date.day} through {end_month} {end_date.day}, {end_date.year}"
+    return f"{start_month} {start_date.day}, {start_date.year} through {end_month} {end_date.day}, {end_date.year}"
+
+
+def storage_totals(rows: Sequence[Mapping[str, Any]]) -> tuple[float, float, str | None]:
+    bytes_total = 0.0
+    objects = 0.0
+    timestamp: str | None = None
+    for row in rows:
+        if row.get("metric") == "BucketSizeBytes":
+            bytes_total += numeric(row.get("average"))
+            timestamp = timestamp or str(row.get("timestamp", ""))
+        elif row.get("metric") == "NumberOfObjects" and row.get("storage_type") == "AllStorageTypes":
+            objects = numeric(row.get("average"))
+            timestamp = timestamp or str(row.get("timestamp", ""))
+    return bytes_total, objects, timestamp
+
+
+def build_highlights(
+    *,
+    start: str,
+    end: str,
+    cost_rows: Sequence[Mapping[str, Any]],
+    storage: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    egress_gb = sum_metric(
+        cost_rows,
+        metric="UsageQuantity",
+        unit="GB",
+        group_suffix="Out-Bytes",
+    )
+    public_egress_gb = sum_metric(
+        cost_rows,
+        metric="UsageQuantity",
+        unit="GB",
+        group_exact="DataTransfer-Out-Bytes",
+    )
+    requests = sum_metric(
+        cost_rows,
+        metric="UsageQuantity",
+        unit="Requests",
+        group_prefix="Requests-",
+    )
+    unblended_cost = sum_metric(cost_rows, metric="UnblendedCost")
+    bytes_total, objects, storage_timestamp = storage_totals(storage)
+    storage_tb = bytes_total / 1_000_000_000_000
+    period_label = display_period(start, end)
+    cards = [
+        {
+            "label": "Indexed data stored",
+            "value": f"{storage_tb:.1f} TB",
+            "detail": f"Current S3 storage across {compact_number(objects)} objects.",
+        },
+        {
+            "label": "Objects available",
+            "value": compact_number(objects),
+            "detail": "Public files, archives, indexes, checksums, and reports in genome-idx.",
+        },
+        {
+            "label": "Data served this period",
+            "value": f"{egress_gb / 1000:.1f} TB",
+            "detail": f"S3 transfer out from {period_label}.",
+        },
+        {
+            "label": "S3 requests this period",
+            "value": compact_number(requests),
+            "detail": "Cost Explorer request classes for the same period.",
+        },
+    ]
+    return {
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+        "period": {"start": start, "end": end, "label": period_label},
+        "first_known_log_date": FIRST_KNOWN_LOG_DATE,
+        "storage_timestamp": storage_timestamp,
+        "metrics": {
+            "egress_gb": egress_gb,
+            "public_egress_gb": public_egress_gb,
+            "requests": requests,
+            "unblended_cost_usd": unblended_cost,
+            "storage_bytes": bytes_total,
+            "storage_tb_decimal": storage_tb,
+            "objects": objects,
+        },
+        "cards": cards,
+    }
+
+
+def snapshot_document(args: argparse.Namespace) -> dict[str, Any]:
+    cost_args = argparse.Namespace(
+        profile=args.profile,
+        region=args.region,
+        start=args.start,
+        end=args.end,
+        granularity=args.granularity,
+        metrics="UnblendedCost,UsageQuantity",
+        service="Amazon Simple Storage Service",
+        group_by="USAGE_TYPE",
+    )
+    storage_args = argparse.Namespace(
+        profile=args.profile,
+        region=args.region,
+        bucket=args.bucket,
+        days=args.storage_days,
+    )
+    cost_rows = get_cost_rows(cost_args)
+    storage = storage_rows(storage_args)
+    log_args = argparse.Namespace(
+        inputs=args.inputs,
+        cache_dir=args.cache_dir,
+        start=args.start,
+        end=args.end,
+        skip_bad_lines=args.skip_bad_lines,
+        window_minutes=args.window_minutes,
+        complete_threshold=args.complete_threshold,
+    )
+    logs_summary: list[dict[str, Any]] = []
+    downloads_summary: list[dict[str, Any]] = []
+    if not args.no_logs:
+        logs_summary = summarize_logs(log_args)
+        downloads_summary = summarize_downloads(log_args)
+    highlights = build_highlights(start=args.start, end=args.end, cost_rows=cost_rows, storage=storage)
+    return {
+        "generated_at": highlights["generated_at"],
+        "bucket": args.bucket,
+        "log_bucket": args.log_bucket,
+        "period": highlights["period"],
+        "highlights": highlights,
+        "cost": cost_rows,
+        "storage": storage,
+        "logs": {
+            "summary": logs_summary,
+            "downloads": downloads_summary,
+            "privacy": "Raw client IPs are not emitted. Download coalescing uses hashed client fingerprints only.",
+        },
+    }
+
+
+def highlights_document(args: argparse.Namespace) -> dict[str, Any]:
+    cost_args = argparse.Namespace(
+        profile=args.profile,
+        region=args.region,
+        start=args.start,
+        end=args.end,
+        granularity=args.granularity,
+        metrics="UnblendedCost,UsageQuantity",
+        service="Amazon Simple Storage Service",
+        group_by="USAGE_TYPE",
+    )
+    storage_args = argparse.Namespace(
+        profile=args.profile,
+        region=args.region,
+        bucket=args.bucket,
+        days=args.storage_days,
+    )
+    return build_highlights(
+        start=args.start,
+        end=args.end,
+        cost_rows=get_cost_rows(cost_args),
+        storage=storage_rows(storage_args),
+    )
+
+
 def add_common_aws_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--profile", default=os.environ.get("AWS_PROFILE", DEFAULT_PROFILE))
     parser.add_argument("--region", default=os.environ.get("AWS_REGION", DEFAULT_REGION))
@@ -659,6 +891,33 @@ def build_parser() -> argparse.ArgumentParser:
     storage.add_argument("--bucket", default=DEFAULT_BUCKET)
     storage.add_argument("--days", type=int, default=14)
     storage.set_defaults(func=lambda args: write_rows(storage_rows(args), fmt=args.format, output=args.output))
+
+    highlights = subparsers.add_parser("highlights", help="Build website-ready usage highlight JSON.")
+    add_common_aws_args(highlights)
+    highlights.add_argument("--start", required=True, help="Inclusive start date, YYYY-MM-DD.")
+    highlights.add_argument("--end", required=True, help="Exclusive end date, YYYY-MM-DD.")
+    highlights.add_argument("--granularity", choices=("DAILY", "MONTHLY"), default="DAILY")
+    highlights.add_argument("--bucket", default=DEFAULT_BUCKET)
+    highlights.add_argument("--storage-days", type=int, default=14)
+    highlights.add_argument("--output", help="Write highlight JSON to this file instead of stdout.")
+    highlights.set_defaults(func=lambda args: write_json_document(highlights_document(args), args.output))
+
+    snapshot = subparsers.add_parser("snapshot", help="Build a JSON snapshot for the static explorer UI.")
+    add_common_aws_args(snapshot)
+    snapshot.add_argument("--start", required=True, help="Inclusive start date, YYYY-MM-DD.")
+    snapshot.add_argument("--end", required=True, help="Exclusive end date, YYYY-MM-DD.")
+    snapshot.add_argument("--granularity", choices=("DAILY", "MONTHLY"), default="DAILY")
+    snapshot.add_argument("--bucket", default=DEFAULT_BUCKET)
+    snapshot.add_argument("--log-bucket", default=DEFAULT_LOG_BUCKET)
+    snapshot.add_argument("--cache-dir", default=str(DEFAULT_CACHE_DIR))
+    snapshot.add_argument("--storage-days", type=int, default=14)
+    snapshot.add_argument("--window-minutes", type=float, default=15.0)
+    snapshot.add_argument("--complete-threshold", type=float, default=0.95)
+    snapshot.add_argument("--skip-bad-lines", action="store_true")
+    snapshot.add_argument("--no-logs", action="store_true", help="Skip cached access-log summaries.")
+    snapshot.add_argument("--output", help="Write snapshot JSON to this file instead of stdout.")
+    snapshot.add_argument("inputs", nargs="*", help="Cached log files or directories. Defaults to --cache-dir.")
+    snapshot.set_defaults(func=lambda args: write_json_document(snapshot_document(args), args.output))
 
     return parser
 

--- a/tools/usage/index_zone_usage.py
+++ b/tools/usage/index_zone_usage.py
@@ -638,6 +638,14 @@ def compact_number(value: float) -> str:
     return f"{value:.1f}"
 
 
+def compact_money(value: float) -> str:
+    if value >= 1_000_000:
+        return f"${value / 1_000_000:.1f}M"
+    if value >= 1_000:
+        return f"${value / 1_000:.1f}K"
+    return f"${value:,.0f}"
+
+
 def end_minus_one(end: str) -> str:
     return (dt.date.fromisoformat(end) - dt.timedelta(days=1)).isoformat()
 
@@ -701,7 +709,10 @@ def build_highlights(
     bytes_total, objects, storage_timestamp = storage_totals(storage)
     storage_tb = bytes_total / 1_000_000_000_000
     weekly_egress_gb = egress_gb / period_days(start, end) * 7
+    weekly_unblended_cost = unblended_cost / period_days(start, end) * 7
     period_label = display_period(start, end)
+    generated_at = dt.datetime.now(dt.timezone.utc)
+    updated_label = f"{generated_at.strftime('%B')} {generated_at.day}, {generated_at.year}"
     cards = [
         {
             "label": "Indexed data stored",
@@ -737,9 +748,14 @@ def build_highlights(
             "label": "Data served per week",
             "value": f"{weekly_egress_gb / 1000:.1f} TB",
         },
+        {
+            "label": "AWS charges per week",
+            "value": compact_money(weekly_unblended_cost),
+        },
     ]
     return {
-        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+        "generated_at": generated_at.isoformat(timespec="seconds"),
+        "updated_label": updated_label,
         "period": {"start": start, "end": end, "label": period_label},
         "first_known_log_date": FIRST_KNOWN_LOG_DATE,
         "storage_timestamp": storage_timestamp,
@@ -747,6 +763,7 @@ def build_highlights(
             "egress_gb": egress_gb,
             "public_egress_gb": public_egress_gb,
             "weekly_egress_gb": weekly_egress_gb,
+            "weekly_unblended_cost_usd": weekly_unblended_cost,
             "requests": requests,
             "unblended_cost_usd": unblended_cost,
             "storage_bytes": bytes_total,

--- a/tools/usage/index_zone_usage.py
+++ b/tools/usage/index_zone_usage.py
@@ -746,11 +746,11 @@ def build_highlights(
         },
         {
             "label": "Data served per week",
-            "value": f"{weekly_egress_gb / 1000:.1f} TB",
+            "value": f"~{weekly_egress_gb / 1000:.1f} TB",
         },
         {
             "label": "AWS charges per week",
-            "value": compact_money(weekly_unblended_cost),
+            "value": f"~{compact_money(weekly_unblended_cost)}",
         },
     ]
     return {

--- a/tools/usage/index_zone_usage.py
+++ b/tools/usage/index_zone_usage.py
@@ -715,7 +715,7 @@ def build_highlights(
     updated_label = f"{generated_at.strftime('%B')} {generated_at.day}, {generated_at.year}"
     cards = [
         {
-            "label": "Indexed data stored",
+            "label": "Data stored",
             "value": f"{storage_tb:.1f} TB",
             "detail": f"Current S3 storage across {compact_number(objects)} objects.",
         },
@@ -737,7 +737,7 @@ def build_highlights(
     ]
     site_cards = [
         {
-            "label": "Indexed data stored",
+            "label": "Data stored",
             "value": f"{storage_tb:.1f} TB",
         },
         {
@@ -745,11 +745,11 @@ def build_highlights(
             "value": compact_number(objects),
         },
         {
-            "label": "Data served per week",
+            "label": "Served / week",
             "value": f"~{weekly_egress_gb / 1000:.1f} TB",
         },
         {
-            "label": "AWS charges per week",
+            "label": "AWS charges / week",
             "value": f"~{compact_money(weekly_unblended_cost)}",
             "note": "Thank you, AWS!",
         },

--- a/tools/usage/index_zone_usage.py
+++ b/tools/usage/index_zone_usage.py
@@ -751,6 +751,7 @@ def build_highlights(
         {
             "label": "AWS charges per week",
             "value": f"~{compact_money(weekly_unblended_cost)}",
+            "note": "Thank you, AWS!",
         },
     ]
     return {

--- a/tools/usage/tests/test_index_zone_usage.py
+++ b/tools/usage/tests/test_index_zone_usage.py
@@ -98,6 +98,61 @@ class S3AccessLogTests(unittest.TestCase):
 
         self.assertEqual(len(sessions), 2)
 
+    def test_build_highlights(self):
+        cost_rows = [
+            {
+                "group": "DataTransfer-Out-Bytes",
+                "metric": "UsageQuantity",
+                "amount": "1500",
+                "unit": "GB",
+            },
+            {
+                "group": "USE1-USW2-AWS-Out-Bytes",
+                "metric": "UsageQuantity",
+                "amount": "500",
+                "unit": "GB",
+            },
+            {
+                "group": "Requests-Tier2",
+                "metric": "UsageQuantity",
+                "amount": "20000",
+                "unit": "Requests",
+            },
+            {
+                "group": "DataTransfer-Out-Bytes",
+                "metric": "UnblendedCost",
+                "amount": "75",
+                "unit": "USD",
+            },
+        ]
+        storage = [
+            {
+                "metric": "BucketSizeBytes",
+                "storage_type": "StandardStorage",
+                "average": 2_500_000_000_000,
+                "timestamp": "2026-05-22T00:00:00Z",
+            },
+            {
+                "metric": "NumberOfObjects",
+                "storage_type": "AllStorageTypes",
+                "average": 12345,
+                "timestamp": "2026-05-22T00:00:00Z",
+            },
+        ]
+
+        highlights = usage.build_highlights(
+            start="2026-05-01",
+            end="2026-05-24",
+            cost_rows=cost_rows,
+            storage=storage,
+        )
+
+        self.assertEqual(highlights["metrics"]["egress_gb"], 2000)
+        self.assertEqual(highlights["metrics"]["public_egress_gb"], 1500)
+        self.assertEqual(highlights["metrics"]["requests"], 20000)
+        self.assertEqual(highlights["cards"][0]["value"], "2.5 TB")
+        self.assertEqual(highlights["period"]["label"], "May 1 through May 23, 2026")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/usage/tests/test_index_zone_usage.py
+++ b/tools/usage/tests/test_index_zone_usage.py
@@ -149,8 +149,11 @@ class S3AccessLogTests(unittest.TestCase):
 
         self.assertEqual(highlights["metrics"]["egress_gb"], 2000)
         self.assertEqual(highlights["metrics"]["public_egress_gb"], 1500)
+        self.assertEqual(highlights["metrics"]["weekly_egress_gb"], 2000 / 23 * 7)
         self.assertEqual(highlights["metrics"]["requests"], 20000)
         self.assertEqual(highlights["cards"][0]["value"], "2.5 TB")
+        self.assertEqual(highlights["site_cards"][1]["label"], "Files available")
+        self.assertEqual(highlights["site_cards"][2]["value"], "0.6 TB")
         self.assertEqual(highlights["period"]["label"], "May 1 through May 23, 2026")
 
 

--- a/tools/usage/tests/test_index_zone_usage.py
+++ b/tools/usage/tests/test_index_zone_usage.py
@@ -157,6 +157,7 @@ class S3AccessLogTests(unittest.TestCase):
         self.assertEqual(highlights["site_cards"][2]["value"], "~0.6 TB")
         self.assertEqual(highlights["site_cards"][3]["label"], "AWS charges per week")
         self.assertEqual(highlights["site_cards"][3]["value"], "~$23")
+        self.assertEqual(highlights["site_cards"][3]["note"], "Thank you, AWS!")
         self.assertIn("updated_label", highlights)
         self.assertEqual(highlights["period"]["label"], "May 1 through May 23, 2026")
 

--- a/tools/usage/tests/test_index_zone_usage.py
+++ b/tools/usage/tests/test_index_zone_usage.py
@@ -155,7 +155,7 @@ class S3AccessLogTests(unittest.TestCase):
         self.assertEqual(highlights["cards"][0]["value"], "2.5 TB")
         self.assertEqual(highlights["site_cards"][1]["label"], "Files available")
         self.assertEqual(highlights["site_cards"][2]["value"], "~0.6 TB")
-        self.assertEqual(highlights["site_cards"][3]["label"], "AWS charges per week")
+        self.assertEqual(highlights["site_cards"][3]["label"], "AWS charges / week")
         self.assertEqual(highlights["site_cards"][3]["value"], "~$23")
         self.assertEqual(highlights["site_cards"][3]["note"], "Thank you, AWS!")
         self.assertIn("updated_label", highlights)

--- a/tools/usage/tests/test_index_zone_usage.py
+++ b/tools/usage/tests/test_index_zone_usage.py
@@ -154,9 +154,9 @@ class S3AccessLogTests(unittest.TestCase):
         self.assertEqual(highlights["metrics"]["requests"], 20000)
         self.assertEqual(highlights["cards"][0]["value"], "2.5 TB")
         self.assertEqual(highlights["site_cards"][1]["label"], "Files available")
-        self.assertEqual(highlights["site_cards"][2]["value"], "0.6 TB")
+        self.assertEqual(highlights["site_cards"][2]["value"], "~0.6 TB")
         self.assertEqual(highlights["site_cards"][3]["label"], "AWS charges per week")
-        self.assertEqual(highlights["site_cards"][3]["value"], "$23")
+        self.assertEqual(highlights["site_cards"][3]["value"], "~$23")
         self.assertIn("updated_label", highlights)
         self.assertEqual(highlights["period"]["label"], "May 1 through May 23, 2026")
 

--- a/tools/usage/tests/test_index_zone_usage.py
+++ b/tools/usage/tests/test_index_zone_usage.py
@@ -150,10 +150,14 @@ class S3AccessLogTests(unittest.TestCase):
         self.assertEqual(highlights["metrics"]["egress_gb"], 2000)
         self.assertEqual(highlights["metrics"]["public_egress_gb"], 1500)
         self.assertEqual(highlights["metrics"]["weekly_egress_gb"], 2000 / 23 * 7)
+        self.assertEqual(highlights["metrics"]["weekly_unblended_cost_usd"], 75 / 23 * 7)
         self.assertEqual(highlights["metrics"]["requests"], 20000)
         self.assertEqual(highlights["cards"][0]["value"], "2.5 TB")
         self.assertEqual(highlights["site_cards"][1]["label"], "Files available")
         self.assertEqual(highlights["site_cards"][2]["value"], "0.6 TB")
+        self.assertEqual(highlights["site_cards"][3]["label"], "AWS charges per week")
+        self.assertEqual(highlights["site_cards"][3]["value"], "$23")
+        self.assertIn("updated_label", highlights)
         self.assertEqual(highlights["period"]["label"], "May 1 through May 23, 2026")
 
 

--- a/tools/usage/ui/index.html
+++ b/tools/usage/ui/index.html
@@ -341,7 +341,7 @@
       period: { start: "2026-05-01", end: "2026-05-24", label: "May 1 through May 23, 2026" },
       highlights: {
         cards: [
-          { label: "Indexed data stored", value: "28.1 TB", detail: "Current S3 storage across 4,631 objects." },
+          { label: "Data stored", value: "28.1 TB", detail: "Current S3 storage across 4,631 objects." },
           { label: "Objects available", value: "4,631", detail: "Public files, archives, indexes, checksums, and reports in genome-idx." },
           { label: "Data served this period", value: "167.6 TB", detail: "S3 transfer out from May 1 through May 23, 2026." },
           { label: "S3 requests this period", value: "610K", detail: "Cost Explorer request classes for the same period." }

--- a/tools/usage/ui/index.html
+++ b/tools/usage/ui/index.html
@@ -70,6 +70,14 @@
       background: var(--panel);
       color: var(--accent-strong);
     }
+    .select-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--muted);
+      font-size: 0.88rem;
+      font-weight: 600;
+    }
     input[type="file"] { display: none; }
     input[type="search"],
     select {
@@ -128,28 +136,47 @@
       grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
       gap: 18px;
     }
+    .panel-heading {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .panel-heading h2 {
+      margin: 0;
+    }
+    .panel-heading .muted {
+      font-size: 0.82rem;
+      text-align: right;
+    }
     .bar-chart {
       display: grid;
       gap: 8px;
     }
     .bar-row {
       display: grid;
-      grid-template-columns: 110px 1fr 90px;
+      grid-template-columns: 130px 1fr 110px;
       gap: 10px;
       align-items: center;
       min-height: 26px;
       font-size: 0.88rem;
     }
     .bar-track {
+      display: block;
       height: 12px;
       border-radius: 999px;
       background: var(--accent-soft);
       overflow: hidden;
     }
     .bar-fill {
+      display: block;
       height: 100%;
       min-width: 2px;
       background: var(--accent);
+    }
+    .bar-fill.secondary {
+      background: #2563eb;
     }
     .table-wrap {
       overflow-x: auto;
@@ -184,8 +211,30 @@
       min-width: 280px;
       word-break: break-word;
     }
+    .numeric {
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+    }
+    .category-badge {
+      display: inline-block;
+      padding: 2px 7px;
+      border-radius: 999px;
+      background: var(--accent-soft);
+      color: var(--accent-strong);
+      font-size: 0.78rem;
+      font-weight: 700;
+    }
+    .category-badge.transfer { background: #dff5f2; color: #0f766e; }
+    .category-badge.storage { background: #e0ecff; color: #1d4ed8; }
+    .category-badge.requests { background: #f4e8ff; color: #7e22ce; }
+    .category-badge.other { background: #eef2f7; color: #475569; }
     tr:last-child td { border-bottom: 0; }
     .muted { color: var(--muted); }
+    .chart-note {
+      margin: 10px 0 0;
+      color: var(--muted);
+      font-size: 0.82rem;
+    }
     .empty {
       padding: 18px;
       background: var(--warn-soft);
@@ -197,7 +246,15 @@
       header { position: static; }
       main { padding: 16px; }
       .grid-2 { grid-template-columns: 1fr; }
-      .bar-row { grid-template-columns: 92px 1fr 72px; }
+      .bar-row { grid-template-columns: 96px 1fr 76px; }
+      .panel-heading {
+        display: block;
+      }
+      .panel-heading .muted {
+        display: block;
+        margin-top: 2px;
+        text-align: left;
+      }
     }
   </style>
 </head>
@@ -208,6 +265,20 @@
       <label class="file-label" for="snapshot-file">Snapshot JSON</label>
       <input id="snapshot-file" type="file" accept="application/json,.json">
       <button class="secondary" id="demo-button" type="button">Demo Data</button>
+      <label class="select-label" for="rollup">Rollup
+        <select id="rollup">
+          <option value="day">Daily</option>
+          <option value="week">Weekly</option>
+          <option value="month">Monthly</option>
+        </select>
+      </label>
+      <label class="select-label" for="top-window">Top files
+        <select id="top-window">
+          <option value="day">Last day</option>
+          <option value="week" selected>Last week</option>
+          <option value="month">Last month</option>
+        </select>
+      </label>
       <select id="prefix-filter" aria-label="Prefix filter"></select>
       <input id="search" type="search" placeholder="Filter keys">
     </div>
@@ -218,13 +289,33 @@
 
     <section class="grid-2">
       <div class="panel">
-        <h2>Daily Transfer Out</h2>
+        <div class="panel-heading">
+          <h2>Data Served</h2>
+          <span class="muted" id="egress-period"></span>
+        </div>
         <div id="egress-chart" class="bar-chart"></div>
       </div>
       <div class="panel">
-        <h2>Cost Explorer Breakdown</h2>
-        <div id="cost-table" class="table-wrap"></div>
+        <div class="panel-heading">
+          <h2>Estimated Downloads</h2>
+          <span class="muted" id="downloads-period"></span>
+        </div>
+        <div id="downloads-chart" class="bar-chart"></div>
       </div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-heading">
+        <h2>Top Downloaded Files</h2>
+        <span class="muted" id="top-files-period"></span>
+      </div>
+      <div id="top-files-table" class="table-wrap"></div>
+      <p class="chart-note">File cost is estimated from effective transfer-out and S3 request rates in the selected snapshot period.</p>
+    </section>
+
+    <section class="panel">
+      <h2>Cost Explorer Breakdown</h2>
+      <div id="cost-table" class="table-wrap"></div>
     </section>
 
     <section class="panel">
@@ -239,47 +330,158 @@
   </main>
 
   <script>
+    function costRow(start, group, metric, amount, unit) {
+      const end = addDays(start, 1);
+      return { start, end, group, metric, amount: String(amount), unit };
+    }
+
     const demoSnapshot = {
-      generated_at: "2026-05-24T14:55:00+00:00",
+      generated_at: "2026-05-24T15:11:31+00:00",
       bucket: "genome-idx",
-      period: { start: "2026-05-23", end: "2026-05-24", label: "2026-05-23 through 2026-05-23" },
+      period: { start: "2026-05-01", end: "2026-05-24", label: "May 1 through May 23, 2026" },
       highlights: {
         cards: [
           { label: "Indexed data stored", value: "28.1 TB", detail: "Current S3 storage across 4,631 objects." },
           { label: "Objects available", value: "4,631", detail: "Public files, archives, indexes, checksums, and reports in genome-idx." },
-          { label: "Data served this period", value: "4.0 TB", detail: "S3 transfer out from 2026-05-23." },
-          { label: "S3 requests this period", value: "6,708", detail: "Cost Explorer request classes for the same period." }
+          { label: "Data served this period", value: "167.6 TB", detail: "S3 transfer out from May 1 through May 23, 2026." },
+          { label: "S3 requests this period", value: "610K", detail: "Cost Explorer request classes for the same period." }
         ]
       },
       cost: [
-        { start: "2026-05-23", end: "2026-05-24", group: "DataTransfer-Out-Bytes", metric: "UsageQuantity", amount: "4015.0623868711", unit: "GB" },
-        { start: "2026-05-23", end: "2026-05-24", group: "USE1-USW2-AWS-Out-Bytes", metric: "UsageQuantity", amount: "5.5235595182", unit: "GB" },
-        { start: "2026-05-23", end: "2026-05-24", group: "Requests-INT-Tier2", metric: "UsageQuantity", amount: "5903", unit: "Requests" }
+        costRow("2026-05-02", "DataTransfer-Out-Bytes", "UnblendedCost", 88.42, "USD"),
+        costRow("2026-05-02", "DataTransfer-Out-Bytes", "UsageQuantity", 1768.4, "GB"),
+        costRow("2026-05-02", "Requests-Tier2", "UnblendedCost", 0.0031, "USD"),
+        costRow("2026-05-02", "Requests-Tier2", "UsageQuantity", 7750, "Requests"),
+        costRow("2026-05-02", "TimedStorage-INT-FA-ByteHrs", "UnblendedCost", 7.82, "USD"),
+        costRow("2026-05-02", "TimedStorage-INT-FA-ByteHrs", "UsageQuantity", 372.1, "GB-Month"),
+        costRow("2026-05-17", "DataTransfer-Out-Bytes", "UnblendedCost", 121.54, "USD"),
+        costRow("2026-05-17", "DataTransfer-Out-Bytes", "UsageQuantity", 2430.8, "GB"),
+        costRow("2026-05-17", "Requests-INT-Tier2", "UnblendedCost", 0.0027, "USD"),
+        costRow("2026-05-17", "Requests-INT-Tier2", "UsageQuantity", 6825, "Requests"),
+        costRow("2026-05-17", "TimedStorage-INT-IA-ByteHrs", "UnblendedCost", 1.98, "USD"),
+        costRow("2026-05-17", "TimedStorage-INT-IA-ByteHrs", "UsageQuantity", 158.5, "GB-Month"),
+        costRow("2026-05-21", "DataTransfer-Out-Bytes", "UnblendedCost", 130.18, "USD"),
+        costRow("2026-05-21", "DataTransfer-Out-Bytes", "UsageQuantity", 2603.6, "GB"),
+        costRow("2026-05-21", "Requests-Tier1", "UnblendedCost", 0.0014, "USD"),
+        costRow("2026-05-21", "Requests-Tier1", "UsageQuantity", 284, "Requests"),
+        costRow("2026-05-21", "TimedStorage-INT-AIA-ByteHrs", "UnblendedCost", 1.25, "USD"),
+        costRow("2026-05-21", "TimedStorage-INT-AIA-ByteHrs", "UsageQuantity", 312.7, "GB-Month"),
+        costRow("2026-05-22", "DataTransfer-Out-Bytes", "UnblendedCost", 159.02, "USD"),
+        costRow("2026-05-22", "DataTransfer-Out-Bytes", "UsageQuantity", 3180.4, "GB"),
+        costRow("2026-05-22", "Requests-INT-Tier2", "UnblendedCost", 0.0037, "USD"),
+        costRow("2026-05-22", "Requests-INT-Tier2", "UsageQuantity", 9325, "Requests"),
+        costRow("2026-05-22", "TimedStorage-ByteHrs", "UnblendedCost", 0.034, "USD"),
+        costRow("2026-05-22", "TimedStorage-ByteHrs", "UsageQuantity", 1.65, "GB-Month"),
+        costRow("2026-05-23", "DataTransfer-Out-Bytes", "UnblendedCost", 200.7531193427, "USD"),
+        costRow("2026-05-23", "DataTransfer-Out-Bytes", "UsageQuantity", 4015.0623868711, "GB"),
+        costRow("2026-05-23", "USE1-USW2-AWS-Out-Bytes", "UnblendedCost", 0.1104711904, "USD"),
+        costRow("2026-05-23", "USE1-USW2-AWS-Out-Bytes", "UsageQuantity", 5.5235595182, "GB"),
+        costRow("2026-05-23", "Requests-INT-Tier2", "UnblendedCost", 0.0023612, "USD"),
+        costRow("2026-05-23", "Requests-INT-Tier2", "UsageQuantity", 5903, "Requests"),
+        costRow("2026-05-23", "Requests-Tier1", "UnblendedCost", 0.00146, "USD"),
+        costRow("2026-05-23", "Requests-Tier1", "UsageQuantity", 292, "Requests"),
+        costRow("2026-05-23", "TimedStorage-INT-FA-ByteHrs", "UnblendedCost", 7.8307840238, "USD"),
+        costRow("2026-05-23", "TimedStorage-INT-FA-ByteHrs", "UsageQuantity", 372.8944773248, "GB-Month")
       ],
       logs: {
         downloads: [
           {
-            date: "2026-05-22",
+            date: "2026-05-23",
             prefix: "kraken",
             key: "kraken/k2_standard_20260226.tar.gz",
-            download_sessions: 1,
-            likely_complete_sessions: 0,
-            likely_partial_sessions: 1,
-            raw_get_requests: 41,
-            bytes_sent: 343732820,
+            download_sessions: 53,
+            likely_complete_sessions: 48,
+            likely_partial_sessions: 5,
+            raw_get_requests: 2100,
+            bytes_sent: 4250000000000,
             max_object_size: 80230502610
+          },
+          {
+            date: "2026-05-23",
+            prefix: "bt",
+            key: "bt/grch38_1kgmaj.zip",
+            download_sessions: 41,
+            likely_complete_sessions: 39,
+            likely_partial_sessions: 2,
+            raw_get_requests: 820,
+            bytes_sent: 720000000000,
+            max_object_size: 17560975630
+          },
+          {
+            date: "2026-05-22",
+            prefix: "hisat",
+            key: "hisat/grch38_tran.tar.gz",
+            download_sessions: 18,
+            likely_complete_sessions: 16,
+            likely_partial_sessions: 2,
+            raw_get_requests: 330,
+            bytes_sent: 90000000000,
+            max_object_size: 5016500000
+          },
+          {
+            date: "2026-05-21",
+            prefix: "centrifuge",
+            key: "centrifuge/p_compressed+h+v.tar.gz",
+            download_sessions: 15,
+            likely_complete_sessions: 14,
+            likely_partial_sessions: 1,
+            raw_get_requests: 290,
+            bytes_sent: 123000000000,
+            max_object_size: 8400000000
+          },
+          {
+            date: "2026-05-17",
+            prefix: "kraken",
+            key: "kraken/k2_pluspf_20260226.tar.gz",
+            download_sessions: 23,
+            likely_complete_sessions: 21,
+            likely_partial_sessions: 2,
+            raw_get_requests: 960,
+            bytes_sent: 1650000000000,
+            max_object_size: 76000000000
+          },
+          {
+            date: "2026-05-02",
+            prefix: "recount",
+            key: "recount/recount3_human_v2.tar.gz",
+            download_sessions: 12,
+            likely_complete_sessions: 10,
+            likely_partial_sessions: 2,
+            raw_get_requests: 510,
+            bytes_sent: 420000000000,
+            max_object_size: 35000000000
           }
         ],
         summary: [
           {
-            date: "2026-05-22",
+            date: "2026-05-23",
             prefix: "kraken",
             key: "kraken/k2_standard_20260226.tar.gz",
             operation: "REST.GET.OBJECT",
             http_status: 206,
-            raw_requests: 41,
-            bytes_sent: 343732820,
+            raw_requests: 2100,
+            bytes_sent: 4250000000000,
             max_object_size: 80230502610
+          },
+          {
+            date: "2026-05-23",
+            prefix: "bt",
+            key: "bt/grch38_1kgmaj.zip",
+            operation: "REST.GET.OBJECT",
+            http_status: 206,
+            raw_requests: 820,
+            bytes_sent: 720000000000,
+            max_object_size: 17560975630
+          },
+          {
+            date: "2026-05-22",
+            prefix: "hisat",
+            key: "hisat/grch38_tran.tar.gz",
+            operation: "REST.GET.OBJECT",
+            http_status: 200,
+            raw_requests: 330,
+            bytes_sent: 90000000000,
+            max_object_size: 5016500000
           }
         ]
       }
@@ -288,12 +490,19 @@
     let snapshot = demoSnapshot;
 
     const cardsEl = document.querySelector("#cards");
-    const chartEl = document.querySelector("#egress-chart");
+    const egressChartEl = document.querySelector("#egress-chart");
+    const downloadsChartEl = document.querySelector("#downloads-chart");
     const costTableEl = document.querySelector("#cost-table");
+    const topFilesTableEl = document.querySelector("#top-files-table");
     const downloadsTableEl = document.querySelector("#downloads-table");
     const logsTableEl = document.querySelector("#logs-table");
+    const rollupEl = document.querySelector("#rollup");
+    const topWindowEl = document.querySelector("#top-window");
     const prefixFilterEl = document.querySelector("#prefix-filter");
     const searchEl = document.querySelector("#search");
+    const egressPeriodEl = document.querySelector("#egress-period");
+    const downloadsPeriodEl = document.querySelector("#downloads-period");
+    const topFilesPeriodEl = document.querySelector("#top-files-period");
 
     function number(value) {
       const n = Number(value || 0);
@@ -317,54 +526,150 @@
       return `${compact(n)} B`;
     }
 
+    function gb(value) {
+      const n = number(value);
+      return n >= 1000 ? `${(n / 1000).toFixed(1)} TB` : `${n.toFixed(1)} GB`;
+    }
+
+    function money(value) {
+      const n = number(value);
+      const digits = Math.abs(n) > 0 && Math.abs(n) < 1 ? 4 : 2;
+      return `$${n.toLocaleString(undefined, { minimumFractionDigits: digits, maximumFractionDigits: digits })}`;
+    }
+
+    function unitCost(value) {
+      const n = number(value);
+      if (!n) return "";
+      const digits = Math.abs(n) < 0.001 ? 6 : 4;
+      return `$${n.toLocaleString(undefined, { minimumFractionDigits: digits, maximumFractionDigits: digits })}`;
+    }
+
+    function escapeHtml(value) {
+      return String(value ?? "").replace(/[&<>"']/g, char => ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;"
+      }[char]));
+    }
+
     function rows(path) {
       return path.reduce((current, key) => current && current[key], snapshot) || [];
+    }
+
+    function parseDate(date) {
+      return new Date(`${date}T00:00:00Z`);
+    }
+
+    function isoDate(date) {
+      return date.toISOString().slice(0, 10);
+    }
+
+    function addDays(date, days) {
+      const d = parseDate(date);
+      d.setUTCDate(d.getUTCDate() + days);
+      return isoDate(d);
+    }
+
+    function bucketFor(date, rollup) {
+      const d = parseDate(date);
+      if (rollup === "month") {
+        return date.slice(0, 7);
+      }
+      if (rollup === "week") {
+        const offset = (d.getUTCDay() + 6) % 7;
+        d.setUTCDate(d.getUTCDate() - offset);
+        return isoDate(d);
+      }
+      return date;
+    }
+
+    function bucketLabel(bucket, rollup) {
+      if (rollup === "month") return bucket;
+      if (rollup === "week") return `${bucket} wk`;
+      return bucket;
+    }
+
+    function dateRangeLabel(start, endExclusive) {
+      const end = addDays(endExclusive, -1);
+      return start === end ? start : `${start} through ${end}`;
     }
 
     function renderCards() {
       const cards = (snapshot.highlights && snapshot.highlights.cards) || [];
       cardsEl.innerHTML = cards.map(card => `
         <article class="stat">
-          <span class="stat-value">${card.value}</span>
-          <span class="stat-label">${card.label}</span>
-          <span class="stat-detail">${card.detail || ""}</span>
+          <span class="stat-value">${escapeHtml(card.value)}</span>
+          <span class="stat-label">${escapeHtml(card.label)}</span>
+          <span class="stat-detail">${escapeHtml(card.detail || "")}</span>
         </article>
       `).join("");
     }
 
-    function dailyEgressRows() {
-      const byDate = new Map();
-      rows(["cost"]).forEach(row => {
-        if (row.metric !== "UsageQuantity" || row.unit !== "GB" || !String(row.group).endsWith("Out-Bytes")) return;
-        byDate.set(row.start, (byDate.get(row.start) || 0) + number(row.amount));
+    function aggregateByBucket(data, valueFn) {
+      const rollup = rollupEl.value;
+      const byBucket = new Map();
+      data.forEach(row => {
+        const value = valueFn(row);
+        if (!value) return;
+        const bucket = bucketFor(row.date || row.start, rollup);
+        byBucket.set(bucket, (byBucket.get(bucket) || 0) + value);
       });
-      return [...byDate.entries()].sort(([a], [b]) => a.localeCompare(b));
+      return [...byBucket.entries()].sort(([a], [b]) => a.localeCompare(b));
     }
 
-    function renderChart() {
-      const data = dailyEgressRows();
+    function egressSeries() {
+      rows(["cost"]).forEach(row => {
+        row.date = row.start;
+      });
+      return aggregateByBucket(rows(["cost"]), row => {
+        if (row.metric !== "UsageQuantity" || row.unit !== "GB" || !String(row.group).endsWith("Out-Bytes")) return 0;
+        return number(row.amount);
+      });
+    }
+
+    function downloadSeries() {
+      return aggregateByBucket(filtered(rows(["logs", "downloads"])), row => number(row.download_sessions));
+    }
+
+    function renderBarChart(element, data, formatter, fillClass = "") {
       if (!data.length) {
-        chartEl.innerHTML = `<div class="empty">No transfer rows in this snapshot.</div>`;
+        element.innerHTML = `<div class="empty">No rows in this snapshot.</div>`;
         return;
       }
       const max = Math.max(...data.map(([, value]) => value), 1);
-      chartEl.innerHTML = data.map(([date, gb]) => {
-        const pct = Math.max(1, (gb / max) * 100);
-        const label = gb >= 1000 ? `${(gb / 1000).toFixed(1)} TB` : `${gb.toFixed(1)} GB`;
+      element.innerHTML = data.map(([bucket, value]) => {
+        const pct = Math.max(1, (value / max) * 100);
         return `
           <div class="bar-row">
-            <span>${date}</span>
-            <span class="bar-track"><span class="bar-fill" style="width:${pct}%"></span></span>
-            <span>${label}</span>
+            <span>${escapeHtml(bucketLabel(bucket, rollupEl.value))}</span>
+            <span class="bar-track"><span class="bar-fill ${fillClass}" style="width:${pct}%"></span></span>
+            <span>${escapeHtml(formatter(value))}</span>
           </div>
         `;
       }).join("");
     }
 
+    function renderCharts() {
+      const rollupLabel = rollupEl.options[rollupEl.selectedIndex].textContent.toLowerCase();
+      egressPeriodEl.textContent = rollupLabel;
+      downloadsPeriodEl.textContent = rollupLabel;
+      renderBarChart(egressChartEl, egressSeries(), gb);
+      renderBarChart(downloadsChartEl, downloadSeries(), value => compact(value), "secondary");
+    }
+
+    function costCategory(group) {
+      if (String(group).endsWith("Out-Bytes")) return { key: "transfer", label: "Transfer" };
+      if (String(group).startsWith("Requests-")) return { key: "requests", label: "Requests" };
+      if (/TimedStorage|Storage|Bucket-Hrs|Monitoring/.test(String(group))) return { key: "storage", label: "Storage" };
+      return { key: "other", label: "Other" };
+    }
+
     function groupCostRows() {
       const grouped = new Map();
       rows(["cost"]).forEach(row => {
-        const item = grouped.get(row.group) || { group: row.group, cost: 0, usage: 0, unit: "" };
+        const item = grouped.get(row.group) || { group: row.group, category: costCategory(row.group), cost: 0, usage: 0, unit: "" };
         if (row.metric === "UnblendedCost") item.cost += number(row.amount);
         if (row.metric === "UsageQuantity") {
           item.usage += number(row.amount);
@@ -372,12 +677,12 @@
         }
         grouped.set(row.group, item);
       });
-      return [...grouped.values()].sort((a, b) => b.cost - a.cost || b.usage - a.usage);
+      return [...grouped.values()].sort((a, b) => b.cost - a.cost || a.category.label.localeCompare(b.category.label));
     }
 
     function table(headers, data, mapper) {
       if (!data.length) return `<div class="empty">No rows in this snapshot.</div>`;
-      const head = headers.map(h => `<th>${h}</th>`).join("");
+      const head = headers.map(h => `<th>${escapeHtml(h)}</th>`).join("");
       const body = data.map(row => `<tr>${mapper(row).map(cell => `<td>${cell}</td>`).join("")}</tr>`).join("");
       return `<table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table>`;
     }
@@ -402,12 +707,104 @@
       });
     }
 
+    function snapshotLatestDate() {
+      const dates = [
+        ...rows(["logs", "downloads"]).map(row => row.date),
+        ...rows(["cost"]).map(row => row.start),
+        snapshot.period && snapshot.period.end ? addDays(snapshot.period.end, -1) : null
+      ].filter(Boolean);
+      return dates.length ? dates.sort().at(-1) : isoDate(new Date());
+    }
+
+    function selectedTopWindow() {
+      const latest = snapshotLatestDate();
+      const days = { day: 1, week: 7, month: 31 }[topWindowEl.value] || 7;
+      const start = addDays(latest, -(days - 1));
+      const end = addDays(latest, 1);
+      return { start, end, label: dateRangeLabel(start, end) };
+    }
+
+    function costRowsInRange(start, end) {
+      return rows(["cost"]).filter(row => row.start < end && (row.end || addDays(row.start, 1)) > start);
+    }
+
+    function costRates(start, end) {
+      let egressCost = 0;
+      let egressGb = 0;
+      let requestCost = 0;
+      let requests = 0;
+      costRowsInRange(start, end).forEach(row => {
+        const group = String(row.group);
+        if (group.endsWith("Out-Bytes")) {
+          if (row.metric === "UnblendedCost") egressCost += number(row.amount);
+          if (row.metric === "UsageQuantity" && row.unit === "GB") egressGb += number(row.amount);
+        }
+        if (group.startsWith("Requests-")) {
+          if (row.metric === "UnblendedCost") requestCost += number(row.amount);
+          if (row.metric === "UsageQuantity" && row.unit === "Requests") requests += number(row.amount);
+        }
+      });
+      return {
+        egressCostPerGb: egressGb ? egressCost / egressGb : 0,
+        requestCostPerRequest: requests ? requestCost / requests : 0
+      };
+    }
+
+    function topDownloadedFiles() {
+      const { start, end, label } = selectedTopWindow();
+      topFilesPeriodEl.textContent = label;
+      const rates = costRates(start, end);
+      const grouped = new Map();
+      filtered(rows(["logs", "downloads"]))
+        .filter(row => row.date >= start && row.date < end)
+        .forEach(row => {
+          const key = row.key || "";
+          const current = grouped.get(key) || {
+            prefix: row.prefix || "",
+            key,
+            download_sessions: 0,
+            raw_get_requests: 0,
+            bytes_sent: 0,
+            likely_complete_sessions: 0,
+            likely_partial_sessions: 0
+          };
+          current.download_sessions += number(row.download_sessions);
+          current.raw_get_requests += number(row.raw_get_requests);
+          current.bytes_sent += number(row.bytes_sent);
+          current.likely_complete_sessions += number(row.likely_complete_sessions);
+          current.likely_partial_sessions += number(row.likely_partial_sessions);
+          grouped.set(key, current);
+        });
+      return [...grouped.values()].map(row => ({
+        ...row,
+        estimated_cost: (row.bytes_sent / 1_000_000_000) * rates.egressCostPerGb +
+          row.raw_get_requests * rates.requestCostPerRequest
+      })).sort((a, b) => b.download_sessions - a.download_sessions || b.bytes_sent - a.bytes_sent).slice(0, 10);
+    }
+
+    function renderTopFiles() {
+      topFilesTableEl.innerHTML = table(
+        ["Prefix", "Key", "Downloads", "Raw GETs", "Bytes", "Est. download cost"],
+        topDownloadedFiles(),
+        row => [
+          escapeHtml(row.prefix || ""),
+          `<span class="key">${escapeHtml(row.key || "")}</span>`,
+          compact(row.download_sessions),
+          compact(row.raw_get_requests),
+          bytes(row.bytes_sent),
+          money(row.estimated_cost)
+        ]
+      );
+    }
+
     function renderTables() {
-      const cost = groupCostRows().slice(0, 20);
-      costTableEl.innerHTML = table(["Usage type", "Cost", "Usage"], cost, row => [
-        row.group,
-        `$${row.cost.toLocaleString(undefined, { maximumFractionDigits: 2 })}`,
-        `${compact(row.usage)} ${row.unit || ""}`
+      const cost = groupCostRows().slice(0, 50);
+      costTableEl.innerHTML = table(["Category", "Usage type", "Cost", "Usage", "Effective unit cost"], cost, row => [
+        `<span class="category-badge ${row.category.key}">${escapeHtml(row.category.label)}</span>`,
+        escapeHtml(row.group),
+        money(row.cost),
+        `${compact(row.usage)} ${escapeHtml(row.unit || "")}`,
+        row.usage ? `${unitCost(row.cost / row.usage)} / ${escapeHtml(row.unit || "unit")}` : ""
       ]);
 
       const downloads = filtered(rows(["logs", "downloads"]))
@@ -417,9 +814,9 @@
         ["Date", "Prefix", "Key", "Sessions", "Raw GETs", "Bytes", "Complete", "Partial"],
         downloads,
         row => [
-          row.date,
-          row.prefix || "",
-          `<span class="key">${row.key || ""}</span>`,
+          escapeHtml(row.date),
+          escapeHtml(row.prefix || ""),
+          `<span class="key">${escapeHtml(row.key || "")}</span>`,
           compact(row.download_sessions),
           compact(row.raw_get_requests),
           bytes(row.bytes_sent),
@@ -435,11 +832,11 @@
         ["Date", "Prefix", "Key", "Operation", "Status", "Requests", "Bytes"],
         logSummary,
         row => [
-          row.date,
-          row.prefix || "",
-          `<span class="key">${row.key || ""}</span>`,
-          row.operation,
-          row.http_status,
+          escapeHtml(row.date),
+          escapeHtml(row.prefix || ""),
+          `<span class="key">${escapeHtml(row.key || "")}</span>`,
+          escapeHtml(row.operation),
+          escapeHtml(row.http_status),
           compact(row.raw_requests),
           bytes(row.bytes_sent)
         ]
@@ -449,7 +846,8 @@
     function render() {
       filters();
       renderCards();
-      renderChart();
+      renderCharts();
+      renderTopFiles();
       renderTables();
     }
 
@@ -468,8 +866,18 @@
       snapshot = demoSnapshot;
       render();
     });
-    prefixFilterEl.addEventListener("change", renderTables);
-    searchEl.addEventListener("input", renderTables);
+    rollupEl.addEventListener("change", renderCharts);
+    topWindowEl.addEventListener("change", renderTopFiles);
+    prefixFilterEl.addEventListener("change", () => {
+      renderCharts();
+      renderTopFiles();
+      renderTables();
+    });
+    searchEl.addEventListener("input", () => {
+      renderCharts();
+      renderTopFiles();
+      renderTables();
+    });
 
     render();
   </script>

--- a/tools/usage/ui/index.html
+++ b/tools/usage/ui/index.html
@@ -1,0 +1,477 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Index Zone Usage Explorer</title>
+  <style>
+    :root {
+      --bg: #f7faf9;
+      --panel: #ffffff;
+      --ink: #172033;
+      --muted: #637083;
+      --border: #d9e2e0;
+      --accent: #0d9488;
+      --accent-strong: #0f766e;
+      --accent-soft: #dff5f2;
+      --warn-soft: #fff3d6;
+      --shadow: 0 1px 3px rgba(15, 23, 42, 0.07);
+      --radius: 8px;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.5 var(--font, inherit);
+    }
+    header {
+      padding: 20px 24px 16px;
+      border-bottom: 1px solid var(--border);
+      background: var(--panel);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+    h1 {
+      font-size: 1.35rem;
+      margin: 0 0 12px;
+      letter-spacing: 0;
+    }
+    h2 {
+      font-size: 1rem;
+      margin: 0 0 12px;
+      letter-spacing: 0;
+    }
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+    }
+    .toolbar label,
+    .toolbar button,
+    .toolbar input,
+    .toolbar select {
+      font: inherit;
+    }
+    button,
+    .file-label {
+      border: 1px solid var(--accent);
+      background: var(--accent);
+      color: #fff;
+      border-radius: 6px;
+      padding: 8px 10px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button.secondary {
+      background: var(--panel);
+      color: var(--accent-strong);
+    }
+    input[type="file"] { display: none; }
+    input[type="search"],
+    select {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--panel);
+      color: var(--ink);
+      padding: 8px 10px;
+      min-height: 38px;
+    }
+    main {
+      padding: 24px;
+      display: grid;
+      gap: 18px;
+    }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      gap: 12px;
+    }
+    .stat {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      padding: 14px;
+    }
+    .stat-value {
+      display: block;
+      font-size: 1.65rem;
+      line-height: 1.15;
+      font-weight: 700;
+      color: var(--ink);
+    }
+    .stat-label {
+      display: block;
+      margin-top: 4px;
+      font-weight: 650;
+    }
+    .stat-detail {
+      display: block;
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 0.86rem;
+    }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      padding: 16px;
+      min-width: 0;
+    }
+    .grid-2 {
+      display: grid;
+      grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+      gap: 18px;
+    }
+    .bar-chart {
+      display: grid;
+      gap: 8px;
+    }
+    .bar-row {
+      display: grid;
+      grid-template-columns: 110px 1fr 90px;
+      gap: 10px;
+      align-items: center;
+      min-height: 26px;
+      font-size: 0.88rem;
+    }
+    .bar-track {
+      height: 12px;
+      border-radius: 999px;
+      background: var(--accent-soft);
+      overflow: hidden;
+    }
+    .bar-fill {
+      height: 100%;
+      min-width: 2px;
+      background: var(--accent);
+    }
+    .table-wrap {
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+    }
+    table {
+      width: 100%;
+      min-width: 760px;
+      border-collapse: collapse;
+      font-size: 0.88rem;
+    }
+    th,
+    td {
+      text-align: left;
+      padding: 8px 10px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+      white-space: nowrap;
+    }
+    th {
+      background: var(--accent-soft);
+      color: var(--ink);
+      font-weight: 700;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+    td.key,
+    .key {
+      white-space: normal;
+      min-width: 280px;
+      word-break: break-word;
+    }
+    tr:last-child td { border-bottom: 0; }
+    .muted { color: var(--muted); }
+    .empty {
+      padding: 18px;
+      background: var(--warn-soft);
+      border: 1px solid #f1d48b;
+      border-radius: var(--radius);
+      color: #604400;
+    }
+    @media (max-width: 820px) {
+      header { position: static; }
+      main { padding: 16px; }
+      .grid-2 { grid-template-columns: 1fr; }
+      .bar-row { grid-template-columns: 92px 1fr 72px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Index Zone Usage Explorer</h1>
+    <div class="toolbar">
+      <label class="file-label" for="snapshot-file">Snapshot JSON</label>
+      <input id="snapshot-file" type="file" accept="application/json,.json">
+      <button class="secondary" id="demo-button" type="button">Demo Data</button>
+      <select id="prefix-filter" aria-label="Prefix filter"></select>
+      <input id="search" type="search" placeholder="Filter keys">
+    </div>
+  </header>
+
+  <main>
+    <section class="cards" id="cards"></section>
+
+    <section class="grid-2">
+      <div class="panel">
+        <h2>Daily Transfer Out</h2>
+        <div id="egress-chart" class="bar-chart"></div>
+      </div>
+      <div class="panel">
+        <h2>Cost Explorer Breakdown</h2>
+        <div id="cost-table" class="table-wrap"></div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Estimated Download Sessions</h2>
+      <div id="downloads-table" class="table-wrap"></div>
+    </section>
+
+    <section class="panel">
+      <h2>Raw Access Log Summary</h2>
+      <div id="logs-table" class="table-wrap"></div>
+    </section>
+  </main>
+
+  <script>
+    const demoSnapshot = {
+      generated_at: "2026-05-24T14:55:00+00:00",
+      bucket: "genome-idx",
+      period: { start: "2026-05-23", end: "2026-05-24", label: "2026-05-23 through 2026-05-23" },
+      highlights: {
+        cards: [
+          { label: "Indexed data stored", value: "28.1 TB", detail: "Current S3 storage across 4,631 objects." },
+          { label: "Objects available", value: "4,631", detail: "Public files, archives, indexes, checksums, and reports in genome-idx." },
+          { label: "Data served this period", value: "4.0 TB", detail: "S3 transfer out from 2026-05-23." },
+          { label: "S3 requests this period", value: "6,708", detail: "Cost Explorer request classes for the same period." }
+        ]
+      },
+      cost: [
+        { start: "2026-05-23", end: "2026-05-24", group: "DataTransfer-Out-Bytes", metric: "UsageQuantity", amount: "4015.0623868711", unit: "GB" },
+        { start: "2026-05-23", end: "2026-05-24", group: "USE1-USW2-AWS-Out-Bytes", metric: "UsageQuantity", amount: "5.5235595182", unit: "GB" },
+        { start: "2026-05-23", end: "2026-05-24", group: "Requests-INT-Tier2", metric: "UsageQuantity", amount: "5903", unit: "Requests" }
+      ],
+      logs: {
+        downloads: [
+          {
+            date: "2026-05-22",
+            prefix: "kraken",
+            key: "kraken/k2_standard_20260226.tar.gz",
+            download_sessions: 1,
+            likely_complete_sessions: 0,
+            likely_partial_sessions: 1,
+            raw_get_requests: 41,
+            bytes_sent: 343732820,
+            max_object_size: 80230502610
+          }
+        ],
+        summary: [
+          {
+            date: "2026-05-22",
+            prefix: "kraken",
+            key: "kraken/k2_standard_20260226.tar.gz",
+            operation: "REST.GET.OBJECT",
+            http_status: 206,
+            raw_requests: 41,
+            bytes_sent: 343732820,
+            max_object_size: 80230502610
+          }
+        ]
+      }
+    };
+
+    let snapshot = demoSnapshot;
+
+    const cardsEl = document.querySelector("#cards");
+    const chartEl = document.querySelector("#egress-chart");
+    const costTableEl = document.querySelector("#cost-table");
+    const downloadsTableEl = document.querySelector("#downloads-table");
+    const logsTableEl = document.querySelector("#logs-table");
+    const prefixFilterEl = document.querySelector("#prefix-filter");
+    const searchEl = document.querySelector("#search");
+
+    function number(value) {
+      const n = Number(value || 0);
+      return Number.isFinite(n) ? n : 0;
+    }
+
+    function compact(value) {
+      const n = number(value);
+      if (n >= 1e12) return `${(n / 1e12).toFixed(1)}T`;
+      if (n >= 1e9) return `${(n / 1e9).toFixed(1)}B`;
+      if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+      if (n >= 1e4) return `${(n / 1e3).toFixed(0)}K`;
+      return n.toLocaleString(undefined, { maximumFractionDigits: 1 });
+    }
+
+    function bytes(value) {
+      const n = number(value);
+      if (n >= 1e12) return `${(n / 1e12).toFixed(2)} TB`;
+      if (n >= 1e9) return `${(n / 1e9).toFixed(2)} GB`;
+      if (n >= 1e6) return `${(n / 1e6).toFixed(2)} MB`;
+      return `${compact(n)} B`;
+    }
+
+    function rows(path) {
+      return path.reduce((current, key) => current && current[key], snapshot) || [];
+    }
+
+    function renderCards() {
+      const cards = (snapshot.highlights && snapshot.highlights.cards) || [];
+      cardsEl.innerHTML = cards.map(card => `
+        <article class="stat">
+          <span class="stat-value">${card.value}</span>
+          <span class="stat-label">${card.label}</span>
+          <span class="stat-detail">${card.detail || ""}</span>
+        </article>
+      `).join("");
+    }
+
+    function dailyEgressRows() {
+      const byDate = new Map();
+      rows(["cost"]).forEach(row => {
+        if (row.metric !== "UsageQuantity" || row.unit !== "GB" || !String(row.group).endsWith("Out-Bytes")) return;
+        byDate.set(row.start, (byDate.get(row.start) || 0) + number(row.amount));
+      });
+      return [...byDate.entries()].sort(([a], [b]) => a.localeCompare(b));
+    }
+
+    function renderChart() {
+      const data = dailyEgressRows();
+      if (!data.length) {
+        chartEl.innerHTML = `<div class="empty">No transfer rows in this snapshot.</div>`;
+        return;
+      }
+      const max = Math.max(...data.map(([, value]) => value), 1);
+      chartEl.innerHTML = data.map(([date, gb]) => {
+        const pct = Math.max(1, (gb / max) * 100);
+        const label = gb >= 1000 ? `${(gb / 1000).toFixed(1)} TB` : `${gb.toFixed(1)} GB`;
+        return `
+          <div class="bar-row">
+            <span>${date}</span>
+            <span class="bar-track"><span class="bar-fill" style="width:${pct}%"></span></span>
+            <span>${label}</span>
+          </div>
+        `;
+      }).join("");
+    }
+
+    function groupCostRows() {
+      const grouped = new Map();
+      rows(["cost"]).forEach(row => {
+        const item = grouped.get(row.group) || { group: row.group, cost: 0, usage: 0, unit: "" };
+        if (row.metric === "UnblendedCost") item.cost += number(row.amount);
+        if (row.metric === "UsageQuantity") {
+          item.usage += number(row.amount);
+          item.unit = row.unit;
+        }
+        grouped.set(row.group, item);
+      });
+      return [...grouped.values()].sort((a, b) => b.cost - a.cost || b.usage - a.usage);
+    }
+
+    function table(headers, data, mapper) {
+      if (!data.length) return `<div class="empty">No rows in this snapshot.</div>`;
+      const head = headers.map(h => `<th>${h}</th>`).join("");
+      const body = data.map(row => `<tr>${mapper(row).map(cell => `<td>${cell}</td>`).join("")}</tr>`).join("");
+      return `<table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table>`;
+    }
+
+    function filters() {
+      const prefixes = new Set();
+      rows(["logs", "downloads"]).forEach(row => prefixes.add(row.prefix || ""));
+      rows(["logs", "summary"]).forEach(row => prefixes.add(row.prefix || ""));
+      const current = prefixFilterEl.value;
+      prefixFilterEl.innerHTML = `<option value="">All prefixes</option>` +
+        [...prefixes].filter(Boolean).sort().map(prefix => `<option value="${prefix}">${prefix}</option>`).join("");
+      prefixFilterEl.value = [...prefixes].includes(current) ? current : "";
+    }
+
+    function filtered(data) {
+      const prefix = prefixFilterEl.value;
+      const query = searchEl.value.trim().toLowerCase();
+      return data.filter(row => {
+        if (prefix && row.prefix !== prefix) return false;
+        if (query && !String(row.key || "").toLowerCase().includes(query)) return false;
+        return true;
+      });
+    }
+
+    function renderTables() {
+      const cost = groupCostRows().slice(0, 20);
+      costTableEl.innerHTML = table(["Usage type", "Cost", "Usage"], cost, row => [
+        row.group,
+        `$${row.cost.toLocaleString(undefined, { maximumFractionDigits: 2 })}`,
+        `${compact(row.usage)} ${row.unit || ""}`
+      ]);
+
+      const downloads = filtered(rows(["logs", "downloads"]))
+        .sort((a, b) => number(b.bytes_sent) - number(a.bytes_sent))
+        .slice(0, 100);
+      downloadsTableEl.innerHTML = table(
+        ["Date", "Prefix", "Key", "Sessions", "Raw GETs", "Bytes", "Complete", "Partial"],
+        downloads,
+        row => [
+          row.date,
+          row.prefix || "",
+          `<span class="key">${row.key || ""}</span>`,
+          compact(row.download_sessions),
+          compact(row.raw_get_requests),
+          bytes(row.bytes_sent),
+          compact(row.likely_complete_sessions),
+          compact(row.likely_partial_sessions)
+        ]
+      );
+
+      const logSummary = filtered(rows(["logs", "summary"]))
+        .sort((a, b) => number(b.bytes_sent) - number(a.bytes_sent))
+        .slice(0, 100);
+      logsTableEl.innerHTML = table(
+        ["Date", "Prefix", "Key", "Operation", "Status", "Requests", "Bytes"],
+        logSummary,
+        row => [
+          row.date,
+          row.prefix || "",
+          `<span class="key">${row.key || ""}</span>`,
+          row.operation,
+          row.http_status,
+          compact(row.raw_requests),
+          bytes(row.bytes_sent)
+        ]
+      );
+    }
+
+    function render() {
+      filters();
+      renderCards();
+      renderChart();
+      renderTables();
+    }
+
+    document.querySelector("#snapshot-file").addEventListener("change", event => {
+      const file = event.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.addEventListener("load", () => {
+        snapshot = JSON.parse(reader.result);
+        render();
+      });
+      reader.readAsText(file);
+    });
+
+    document.querySelector("#demo-button").addEventListener("click", () => {
+      snapshot = demoSnapshot;
+      render();
+    });
+    prefixFilterEl.addEventListener("change", renderTables);
+    searchEl.addEventListener("input", renderTables);
+
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Extends the Index Zone usage tooling with a static usage dashboard and homepage usage highlights.

- Adds `snapshot` and `highlights` commands to build dashboard JSON and website-ready stats from Cost Explorer, CloudWatch S3 storage metrics, and cached S3 access-log summaries.
- Adds a dependency-free static usage explorer at `tools/usage/ui/index.html` with daily/weekly/monthly rollups for data served and inferred downloads, top downloaded files, cost estimates, and Cost Explorer breakdowns.
- Adds generated homepage usage data in `docs/_data/usage_highlights.json` and renders compact AWS Open Data cards for data stored, files available, estimated data served per week, and estimated AWS charges per week.
- Keeps raw client IPs out of emitted reports; access-log download coalescing remains hash/fingerprint based.

## Current Homepage Figures

- `28.1 TB` data stored
- `4,631` files available
- `~51.0 TB` served per week
- `~$2.6K` AWS charges per week

## Validation

- `python3 -m unittest tools/usage/tests/test_index_zone_usage.py`
- `python3 -m py_compile tools/usage/index_zone_usage.py tools/usage/tests/test_index_zone_usage.py`
- `python3 -m json.tool docs/_data/usage_highlights.json`
- usage explorer JavaScript syntax check with Node
- `python3 docs/check_site_links.py --root docs --no-network`
- Jekyll build via Homebrew Ruby 4.0.3 with a local Jekyll 3 `tainted?` compatibility shim