### PR TITLE
Bowtie legacy metadata backfill and catalog links

### DIFF
--- a/AWS.md
+++ b/AWS.md
@@ -1,4 +1,24 @@
-Remember that if you need temporary credentials, you can go to:
+For **Index Zone / genome-idx** work on this machine, the AWS CLI v2 flow is:
+
+1. Log in to the console-backed user profile (opens a browser, or use `aws login --remote` over SSH):
+
+   ```bash
+   aws login --profile data-langmead
+   ```
+
+2. Use the role that can list and write `s3://genome-idx/` (see `~/.aws/config` — profile `index-zone-s3` chains from `data-langmead`):
+
+   ```bash
+   export AWS_PROFILE=index-zone-s3
+   ```
+
+For **IAM Identity Center** (e.g. CDK deploy profile `index-zone-ec2`), use:
+
+```bash
+aws sso login --profile index-zone-ec2
+```
+
+Remember that if you need temporary credentials via the JHU portal, you can go to:
 https://jh.awsapps.com/start/#/console?account_id=159168350739
 
 Unfortunately, my instance_shopper.py script doesn't know about architectures (e.g. Xeon versus Graviton).  Another factor that's important is whether there's instance-local storage.  So it could be that I have to narrow my options using more than one script or database.

--- a/build/bowtie/README.md
+++ b/build/bowtie/README.md
@@ -71,6 +71,76 @@ Check that the source FASTA URLs in the target catalog still resolve:
 ./check_sources.bash
 ```
 
+For the legacy metadata backfill catalog:
+
+```bash
+./check_sources.bash --targets legacy_targets.tsv
+```
+
+## Legacy metadata backfill (dict / manifest / build.txt)
+
+Indexes that predate the current CDK workflow often lack `.dict`, `.manifest.json`,
+and `.build.txt` on `s3://genome-idx/bt/` even though the `.bt2` / `.bt2l` shards
+are present.  The metadata-only path reuses existing shards (no `bowtie2-build`),
+downloads a curated reference FASTA from `legacy_targets.tsv`, runs `samtools dict`,
+repacks `.zip`, regenerates `.md5`, and uploads sidecars plus updated zip/md5.
+
+**Inventory (read-only):** compare the catalog to the bucket. Authenticate first
+(`aws login --profile data-langmead`, then `export AWS_PROFILE=index-zone-s3`;
+see `AWS.md` in the repo root), then:
+
+```bash
+python3 audit_s3.py
+python3 audit_s3.py --require-metadata --strict   # after backfill is complete
+```
+
+**Pilot (small genomes):** yeast, BDGP6 fly, WBcel235 worm:
+
+```bash
+./run_pilot_metadata_backfill.bash
+```
+
+**Full legacy batch:** every id in `legacy_targets.tsv`:
+
+```bash
+./run_legacy_metadata_backfill.bash
+```
+
+To **resume** after a partial run, use the audit-driven loop (one id per invocation so
+failures do not stop the batch):
+
+```bash
+./run_resume_missing_metadata_backfill.bash
+```
+
+Progress is appended to `legacy_backfill_resume.log`.  `grch37` is passed `--force`
+because prior runs left partial uploads.  After starting a long batch, you can run
+`./wait_and_audit_legacy_backfill.bash` in another terminal (or `nohup … &`); it
+logs progress every five minutes to `legacy_backfill_watch.log` and runs
+`audit_s3.py --require-metadata --strict` when the main job writes `EXIT:` to
+`legacy_backfill_remaining.log`.
+
+Both runners honor `FROM_S3_PREFIX` and `UPLOAD_PREFIX` (default `s3://genome-idx/bt`).
+Manual invocation for a subset:
+
+```bash
+./build_indexes.bash --metadata-only --backfill \
+  --from-s3-prefix s3://genome-idx/bt \
+  --targets legacy_targets.tsv \
+  --upload-prefix s3://genome-idx/bt \
+  r6411 bdgp6 wbcel235
+```
+
+**Docs / link check:** after uploads, confirm objects (see `audit_s3.py`), regenerate
+`docs/bowtie.md` from `xfer/bt/` per that directory’s workflow, then:
+
+```bash
+cd ../docs && python3 check_site_links.py --only bowtie.md --check-s3
+```
+
+Use `--only` to scope S3 HEAD checks to the Bowtie page; a full-repo run still includes
+unrelated pages and external URLs that may fail independently.
+
 ## CDK build on AWS
 
 This directory also includes a CDK workflow for running the same builder on

--- a/build/bowtie/audit_s3.py
+++ b/build/bowtie/audit_s3.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Compare Bowtie Index Zone catalog (xfer/bt/shortname_map.csv) to objects under
+s3://genome-idx/bt/ (or --bucket/--prefix).
+
+Requires AWS CLI: `aws s3api list-objects-v2` (credentials or public read as
+configured for the bucket).
+
+Usage:
+  cd build/bowtie && python3 audit_s3.py
+  python3 audit_s3.py --strict   # exit 1 if any expected object is missing
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CSV = REPO_ROOT / "xfer" / "bt" / "shortname_map.csv"
+
+INDEX_SUFFIXES = [".1", ".2", ".3", ".4", ".rev.1", ".rev.2"]
+
+
+def parse_shortname_row(row: list[str]) -> tuple[str, str, str, list[str]] | None:
+    """Return (short_id, index_base, index_ext, metadata_types) or None."""
+    if not row or not row[0].strip() or row[0].startswith("#"):
+        return None
+    short = row[0].strip()
+    index_base = row[1].strip()
+    ext = row[6].strip() if len(row) > 6 and row[6].strip() else "bt2"
+    if ext not in ("bt2", "bt2l"):
+        raise ValueError(f"{short}: invalid index extension {ext!r}")
+    meta = ["md5"]
+    if len(row) > 7 and row[7].strip():
+        meta.extend(t.strip() for t in row[7].split(";") if t.strip())
+    allowed = {"md5", "dict", "manifest"}
+    bad = sorted(set(meta) - allowed)
+    if bad:
+        raise ValueError(f"{short}: unknown metadata types {bad}")
+    meta = [m for m in ["md5", "dict", "manifest"] if m in meta]
+    return short, index_base, ext, meta
+
+
+def aws_list_keys(bucket: str, prefix: str) -> set[str]:
+    """Return set of object keys (no bucket) under prefix."""
+    keys: set[str] = set()
+    token = ""
+    while True:
+        cmd = [
+            "aws",
+            "s3api",
+            "list-objects-v2",
+            "--bucket",
+            bucket,
+            "--prefix",
+            prefix,
+            "--output",
+            "json",
+        ]
+        if token:
+            cmd.extend(["--continuation-token", token])
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.returncode != 0:
+            sys.stderr.write(proc.stderr or proc.stdout or "aws s3api failed\n")
+            raise RuntimeError("aws s3api list-objects-v2 failed")
+        data = json.loads(proc.stdout)
+        for obj in data.get("Contents", []) or []:
+            key = obj.get("Key", "")
+            if key:
+                keys.add(key)
+        if not data.get("IsTruncated"):
+            break
+        token = data.get("NextContinuationToken") or ""
+        if not token:
+            break
+    return keys
+
+
+def expected_keys_for_index(
+    index_base: str, ext: str, meta: list[str], require_metadata: bool
+) -> list[str]:
+    p = f"bt/{index_base}"
+    keys = [f"{p}.zip", f"{p}.md5"]
+    for suf in INDEX_SUFFIXES:
+        keys.append(f"{p}{suf}.{ext}")
+    want_sidecars = require_metadata or ("dict" in meta and "manifest" in meta)
+    if want_sidecars:
+        keys.extend([f"{p}.dict", f"{p}.manifest.json", f"{p}.build.txt"])
+    return keys
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Audit Bowtie bt/ objects vs shortname_map.csv")
+    ap.add_argument(
+        "--csv",
+        type=Path,
+        default=DEFAULT_CSV,
+        help="Path to shortname_map.csv",
+    )
+    ap.add_argument("--bucket", default=os.environ.get("BT_AUDIT_BUCKET", "genome-idx"))
+    ap.add_argument("--prefix", default=os.environ.get("BT_AUDIT_PREFIX", "bt/"))
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with status 1 if any catalogued object is missing",
+    )
+    ap.add_argument(
+        "--require-metadata",
+        action="store_true",
+        help="Treat .dict, .manifest.json, .build.txt as required for every index",
+    )
+    args = ap.parse_args()
+
+    prefix = args.prefix
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+
+    rows: list[tuple[str, str, str, list[str]]] = []
+    with open(args.csv, newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        for row in reader:
+            parsed = parse_shortname_row(row)
+            if parsed:
+                rows.append(parsed)
+
+    try:
+        s3_keys = aws_list_keys(args.bucket, prefix)
+    except RuntimeError as e:
+        print(e, file=sys.stderr)
+        return 2
+
+    # Normalize to keys relative to bucket root (list-objects returns full keys)
+    # prefix is e.g. bt/ — keys are like bt/hs1.zip
+    missing_all: list[tuple[str, str]] = []
+    print(f"Bucket s3://{args.bucket}/{prefix} — {len(s3_keys)} objects listed\n")
+
+    for short, index_base, ext, meta in rows:
+        expected = expected_keys_for_index(index_base, ext, meta, args.require_metadata)
+        missing = [k for k in expected if k not in s3_keys]
+        status = "OK" if not missing else "MISSING"
+        meta_s = "+".join(meta) if len(meta) > 1 else meta[0]
+        print(f"{status}\t{short}\t{index_base}\t{ext}\tmeta={meta_s}")
+        for k in missing:
+            print(f"  missing: s3://{args.bucket}/{k}")
+            missing_all.append((short, k))
+        if not missing:
+            print(f"  ({len(expected)} objects)")
+
+    if missing_all:
+        print(f"\nTotal missing: {len(missing_all)}")
+        if args.strict:
+            return 1
+    else:
+        print("\nAll expected objects present.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/bowtie/build_indexes.bash
+++ b/build/bowtie/build_indexes.bash
@@ -15,6 +15,9 @@ force=0
 keep_fasta=0
 upload_prefix="${UPLOAD_PREFIX:-}"
 target_ids=()
+metadata_only=0
+backfill=0
+from_s3_prefix=""
 
 usage() {
     cat <<'USAGE'
@@ -32,6 +35,10 @@ Options:
   --upload-prefix S3_URI  Also upload output artifacts to this S3 prefix.
   --force                 Redownload/rebuild even when outputs exist.
   --keep-fasta            Keep decompressed FASTA files in the work directory.
+  --metadata-only         Skip bowtie2-build; copy existing index shards from --from-s3-prefix.
+  --backfill              With --metadata-only, write dict/manifest/build.txt with unknown
+                          original build fields (requires --from-s3-prefix).
+  --from-s3-prefix URI    S3 prefix holding existing .bt2/.bt2l shards (e.g. s3://genome-idx/bt).
   -h, --help              Show this help.
 
 If no target IDs are given, all targets in the TSV are built.
@@ -109,6 +116,15 @@ md5_value() {
 default_builder_id() {
     local commit suffix status
 
+    if [[ "${backfill:-0}" -eq 1 ]]; then
+        if [[ -n "${INDEX_ZONE_BUILDER:-}" ]]; then
+            printf '%s\n' "$INDEX_ZONE_BUILDER"
+        else
+            printf '%s\n' "aws-indexes:metadata-backfill"
+        fi
+        return 0
+    fi
+
     if [[ -n "${INDEX_ZONE_BUILDER:-}" ]]; then
         printf '%s\n' "$INDEX_ZONE_BUILDER"
     elif git -C "$script_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
@@ -146,6 +162,42 @@ validate_index_files() {
             exit 1
         fi
     done
+}
+
+download_s3_shards() {
+    local index_base="$1"
+    local ext="$2"
+    local prefix="$3"
+    local suffix
+    local src
+
+    require_cmd aws
+    for suffix in .1 .2 .3 .4 .rev.1 .rev.2; do
+        src="${from_s3_prefix%/}/${index_base}${suffix}.${ext}"
+        printf 'Downloading %s\n' "$src"
+        aws s3 cp "$src" "${prefix}${suffix}.${ext}"
+    done
+}
+
+finalize_index_artifacts() {
+    local id="$1"
+    local index_base="$2"
+    local species="$3"
+    local assembly="$4"
+    local source="$5"
+    local url="$6"
+    local expected_ext="$7"
+    local notes="$8"
+    local download="$9"
+    local fasta="${10}"
+    local prefix="${11}"
+    local actual_ext="${12}"
+
+    write_sequence_dictionary "$fasta" "$index_base"
+    write_provenance "$id" "$index_base" "$species" "$assembly" "$source" "$url" "$expected_ext" "$actual_ext" "$notes"
+    write_manifest "$id" "$index_base" "$species" "$assembly" "$source" "$url" "$expected_ext" "$actual_ext" "$notes" "$download" "$fasta" "$prefix"
+    copy_index_artifacts "$prefix" "$index_base" "$actual_ext"
+    upload_outputs "$index_base" "$actual_ext"
 }
 
 copy_index_artifacts() {
@@ -195,14 +247,23 @@ write_manifest() {
     local download="${10}"
     local fasta="${11}"
     local prefix="${12}"
-    local version_line tool_version input_md5 build_command builder_id
+    local version_line tool_version input_md5 build_command builder_id manifest_threads
 
-    version_line="$("$bowtie2_build" --version | head -n 1 || true)"
-    tool_version="$(printf '%s\n' "$version_line" | sed -E 's/.*version ([^[:space:]]+).*/\1/')"
+    if [[ "${backfill:-0}" -eq 1 ]]; then
+        version_line="unknown"
+        tool_version="unknown"
+        build_command="unknown"
+        builder_id="$(default_builder_id)"
+        manifest_threads="unknown"
+    else
+        version_line="$("$bowtie2_build" --version | head -n 1 || true)"
+        tool_version="$(printf '%s\n' "$version_line" | sed -E 's/.*version ([^[:space:]]+).*/\1/')"
+        build_command="$(printf '%q ' "$bowtie2_build" --threads "$threads" "$fasta" "$prefix")"
+        build_command="${build_command% }"
+        builder_id="$(default_builder_id)"
+        manifest_threads="$threads"
+    fi
     input_md5="$(md5_value "$download")"
-    build_command="$(printf '%q ' "$bowtie2_build" --threads "$threads" "$fasta" "$prefix")"
-    build_command="${build_command% }"
-    builder_id="$(default_builder_id)"
 
     INDEX_MANIFEST_PATH="${out_dir}/${index_base}.manifest.json" \
     INDEX_ID="$id" \
@@ -219,7 +280,7 @@ write_manifest() {
     INDEX_TOOL_VERSION="$tool_version" \
     INDEX_TOOL_VERSION_LINE="$version_line" \
     INDEX_COMMAND="$build_command" \
-    INDEX_THREADS="$threads" \
+    INDEX_THREADS="$manifest_threads" \
     INDEX_BUILDER="$builder_id" \
     python3 - <<'PY'
 import json
@@ -290,8 +351,15 @@ write_provenance() {
     local actual_ext="$8"
     local notes="$9"
     local version
+    local thread_line
 
-    version="$("$bowtie2_build" --version | head -n 1 || true)"
+    if [[ "${backfill:-0}" -eq 1 ]]; then
+        version="unknown"
+        thread_line="unknown"
+    else
+        version="$("$bowtie2_build" --version | head -n 1 || true)"
+        thread_line="$threads"
+    fi
 
     {
         printf 'id=%s\n' "$id"
@@ -304,7 +372,7 @@ write_provenance() {
         printf 'actual_ext=%s\n' "$actual_ext"
         printf 'built_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
         printf 'bowtie2_build=%s\n' "$version"
-        printf 'threads=%s\n' "$threads"
+        printf 'threads=%s\n' "$thread_line"
         printf 'notes=%s\n' "$notes"
     } > "${out_dir}/${index_base}.build.txt"
 }
@@ -361,17 +429,72 @@ build_one() {
 
     actual_ext="$(index_ext_for_prefix "$prefix")"
     validate_index_files "$prefix" "$actual_ext"
-    write_sequence_dictionary "$fasta" "$index_base"
-    write_provenance "$id" "$index_base" "$species" "$assembly" "$source" "$url" "$expected_ext" "$actual_ext" "$notes"
-    write_manifest "$id" "$index_base" "$species" "$assembly" "$source" "$url" "$expected_ext" "$actual_ext" "$notes" "$download" "$fasta" "$prefix"
-    copy_index_artifacts "$prefix" "$index_base" "$actual_ext"
-    upload_outputs "$index_base" "$actual_ext"
+    finalize_index_artifacts "$id" "$index_base" "$species" "$assembly" "$source" "$url" "$expected_ext" "$notes" "$download" "$fasta" "$prefix" "$actual_ext"
 
     if [[ "$keep_fasta" -eq 0 ]]; then
         rm -f "$fasta"
     fi
 
     printf 'Finished %s -> %s/%s.zip\n' "$id" "$out_dir" "$index_base"
+}
+
+backfill_one() {
+    local id="$1"
+    local index_base="$2"
+    local species="$3"
+    local assembly="$4"
+    local source="$5"
+    local url="$6"
+    local expected_ext="$7"
+    local notes="$8"
+    local target_work download fasta prefix
+    local merged_notes
+
+    target_work="${work_dir}/${id}"
+    download="${target_work}/source.fa.gz"
+    fasta="${target_work}/source.fa"
+    prefix="${target_work}/${index_base}"
+
+    if [[ "$expected_ext" != "bt2" && "$expected_ext" != "bt2l" ]]; then
+        printf 'error: %s: expected_ext must be bt2 or bt2l, got %s\n' "$id" "$expected_ext" >&2
+        exit 1
+    fi
+
+    if [[ "$force" -eq 0 && -s "${out_dir}/${index_base}.zip" && -s "${out_dir}/${index_base}.dict" && -s "${out_dir}/${index_base}.manifest.json" && -s "${out_dir}/${index_base}.md5" ]]; then
+        printf 'Skipping %s; outputs already exist in %s. Use --force to rebuild.\n' "$id" "$out_dir"
+        return 0
+    fi
+
+    merged_notes="${notes}"
+    if [[ -n "$merged_notes" ]]; then
+        merged_notes="${merged_notes} "
+    fi
+    merged_notes="${merged_notes}Metadata-only backfill; index .${expected_ext} shards unchanged from ${from_s3_prefix}; original bowtie2-build version/date/command not recorded."
+
+    printf 'Backfilling metadata for %s (%s / %s)\n' "$id" "$species" "$assembly"
+    mkdir -p "$target_work"
+
+    if [[ "$force" -eq 1 || ! -s "$download" ]]; then
+        rm -f "$download"
+        "$curl_bin" --fail --location --silent --show-error --retry 5 --retry-delay 10 -o "$download" "$url"
+    fi
+
+    if [[ "$force" -eq 1 || ! -s "$fasta" ]]; then
+        rm -f "$fasta"
+        gzip -cd "$download" > "$fasta"
+    fi
+
+    rm -f "${prefix}".*.bt2 "${prefix}".*.bt2l
+    download_s3_shards "$index_base" "$expected_ext" "$prefix"
+    validate_index_files "$prefix" "$expected_ext"
+
+    finalize_index_artifacts "$id" "$index_base" "$species" "$assembly" "$source" "$url" "$expected_ext" "$merged_notes" "$download" "$fasta" "$prefix" "$expected_ext"
+
+    if [[ "$keep_fasta" -eq 0 ]]; then
+        rm -f "$fasta"
+    fi
+
+    printf 'Finished metadata backfill for %s -> %s/%s.zip\n' "$id" "$out_dir" "$index_base"
 }
 
 while [[ "$#" -gt 0 ]]; do
@@ -408,6 +531,18 @@ while [[ "$#" -gt 0 ]]; do
             keep_fasta=1
             shift
             ;;
+        --metadata-only)
+            metadata_only=1
+            shift
+            ;;
+        --backfill)
+            backfill=1
+            shift
+            ;;
+        --from-s3-prefix)
+            from_s3_prefix="$2"
+            shift 2
+            ;;
         -h|--help)
             usage
             exit 0
@@ -434,12 +569,31 @@ fi
 
 threads="${threads:-$(default_threads)}"
 
-require_cmd "$bowtie2_build"
+if [[ "$metadata_only" -eq 1 ]]; then
+    if [[ "$backfill" -ne 1 ]]; then
+        printf 'error: --metadata-only requires --backfill\n' >&2
+        exit 1
+    fi
+    if [[ -z "$from_s3_prefix" ]]; then
+        printf 'error: --metadata-only requires --from-s3-prefix\n' >&2
+        exit 1
+    fi
+elif [[ "$backfill" -eq 1 ]]; then
+    printf 'error: --backfill is only valid with --metadata-only\n' >&2
+    exit 1
+fi
+
+if [[ "$metadata_only" -eq 0 ]]; then
+    require_cmd "$bowtie2_build"
+fi
 require_cmd "$samtools_bin"
 require_cmd "$curl_bin"
 require_cmd python3
 require_cmd gzip
 require_cmd zip
+if [[ "$metadata_only" -eq 1 ]]; then
+    require_cmd aws
+fi
 
 if [[ ! -f "$targets_file" ]]; then
     printf 'error: target file does not exist: %s\n' "$targets_file" >&2
@@ -453,7 +607,11 @@ while IFS=$'\t' read -r id index_base species assembly source url expected_ext n
     [[ -z "${id:-}" || "${id:0:1}" == "#" ]] && continue
     if target_selected "$id"; then
         matched=$((matched + 1))
-        build_one "$id" "$index_base" "$species" "$assembly" "$source" "$url" "$expected_ext" "$notes"
+        if [[ "$metadata_only" -eq 1 ]]; then
+            backfill_one "$id" "$index_base" "$species" "$assembly" "$source" "$url" "$expected_ext" "$notes"
+        else
+            build_one "$id" "$index_base" "$species" "$assembly" "$source" "$url" "$expected_ext" "$notes"
+        fi
     fi
 done < "$targets_file"
 

--- a/build/bowtie/legacy_targets.tsv
+++ b/build/bowtie/legacy_targets.tsv
@@ -1,0 +1,37 @@
+# id	index_base	species	assembly	source	url	expected_ext	notes
+# Metadata-only backfill catalog: matches xfer/bt/shortname_map.csv rows that do not yet declare dict;manifest.
+# Run: ./build_indexes.bash --metadata-only --backfill --from-s3-prefix s3://genome-idx/bt --targets legacy_targets.tsv --upload-prefix s3://genome-idx/bt <ids...>
+grch38_noalt	GRCh38_noalt_as	Human	GRCh38 no-alt analysis set	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz	bt2	NCBI analysis set (UCSC-style contig names)
+grch38_noalt_decoy	GRCh38_noalt_decoy_as	Human	GRCh38 no-alt +decoy set	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.40_GRCh38.p14/GRCh38_major_release_seqs_for_alignment_pipelines/GCA_000001405.15_GRCh38_no_alt_plus_hs38d1_analysis_set.fna.gz	bt2	NCBI GRCh38.p14 alignment pipelines no-alt plus hs38d1 decoy
+grch38_1kgmaj	grch38_1kgmaj	Human	GRCh38 + major SNVs	NCBI+1KG	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz	bt2	Dict baseline is NCBI no-alt analysis set; index applies 1KG major alleles (see bowtie-majref) so sequence MD5s differ at variant sites
+grch37	GRCh37	Human	GRCh37	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.25_GRCh37.p13/GCF_000001405.25_GRCh37.p13_genomic.fna.gz	bt2	RefSeq GRCh37.p13 primary assembly
+ash1	Ash1v1.7	Human	Ash1v1.7	JHU	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/011/064/465/GCA_011064465.1_Ash1.7/GCA_011064465.1_Ash1.7_genomic.fna.gz	bt2	NCBI GenBank Ash1.7 (GCA_011064465.1); verify against original Ash1v1.7 FASTA if needed
+ash1_2	Ash1_v2.0	Human	Ash1v2.0	JHU	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/011/064/465/GCA_011064465.2_Ash1_v2.2/GCA_011064465.2_Ash1_v2.2_genomic.fna.gz	bt2	NCBI GenBank Ash1_v2.2 (GCA_011064465.2); index name Ash1_v2.0 — verify if patch differs
+t2tplusy	chm13.draft_v1.0_plusY	Human	CHM13plusY	T2T	https://human-pangenomics.s3.us-west-2.amazonaws.com/T2T/CHM13/assemblies/chm13.draft_v1.0.fasta.gz	bt2	CHM13 draft v1.0; index name implies plus-Y assembly—verify dict vs exact reference used for the posted index
+hg19	hg19	Human	hg19	UCSC	https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.fa.gz	bt2	UCSC hg19 full soft-masked FASTA
+hg18	hg18	Human	hg18	UCSC	https://hgdownload.soe.ucsc.edu/goldenPath/hg18/bigZips/hg18.fa.gz	bt2	UCSC hg18 full soft-masked FASTA
+grcm38	GRCm38	Mouse	GRCm38	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/635/GCF_000001635.26_GRCm38.p6/GCF_000001635.26_GRCm38.p6_genomic.fna.gz	bt2	RefSeq GRCm38.p6
+grcm39	GRCm39	Mouse	GRCm39	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/635/GCF_000001635.27_GRCm39/GCF_000001635.27_GRCm39_genomic.fna.gz	bt2	RefSeq GRCm39
+mm10	mm10	Mouse	mm10	UCSC	https://hgdownload.soe.ucsc.edu/goldenPath/mm10/bigZips/mm10.fa.gz	bt2	UCSC mm10
+mm9	mm9	Mouse	mm9	UCSC	https://hgdownload.soe.ucsc.edu/goldenPath/mm9/bigZips/mm9.fa.gz	bt2	UCSC mm9
+clintptr2	Clint_PTRv2	Chimpanzee	Clint_PTRv2	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/002/880/755/GCF_002880755.1_Clint_PTRv2/GCF_002880755.1_Clint_PTRv2_genomic.fna.gz	bt2	RefSeq Clint_PTRv2
+chimp214	CHIMP2.1.4	Chimpanzee	CHIMP2.1.4	Ensembl	https://ftp.ensembl.org/pub/release-80/fasta/pan_troglodytes/dna/Pan_troglodytes.CHIMP2.1.4.dna.toplevel.fa.gz	bt2	Ensembl release-80 CHIMP2.1.4 toplevel
+mmul10	Mmul_10	Rhesus macaque	MMul_10	Ensembl	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/003/339/765/GCF_003339765.1_Mmul_10/GCF_003339765.1_Mmul_10_genomic.fna.gz	bt2	RefSeq Mmul_10
+arsucd12	ARS-UCD1.2	Cow	ARS-UCD1.2	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/002/263/795/GCF_002263795.1_ARS-UCD1.2/GCF_002263795.1_ARS-UCD1.2_genomic.fna.gz	bt2	RefSeq ARS-UCD1.2
+sscorfa111	Sscrofa11.1	Pig	Sscrofa11.1	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/003/025/GCF_000003025.6_Sscrofa11.1/GCF_000003025.6_Sscrofa11.1_genomic.fna.gz	bt2	RefSeq Sscrofa11.1
+canfam31	CanFam3.1	Dog	CanFam3.1	Ensembl	https://ftp.ensembl.org/pub/release-104/fasta/canis_lupus_familiaris/dna/Canis_lupus_familiaris.CanFam3.1.dna.toplevel.fa.gz	bt2	Ensembl release-104 CanFam3.1 toplevel
+canfam4	canfam4	Dog	CanFam4	NCBI	https://hgdownload.soe.ucsc.edu/goldenPath/canFam4/bigZips/canFam4.fa.gz	bt2	UCSC canFam4 (matches common Index Zone naming); NCBI also hosts CanFam4 under a different accession path
+rn4	rn4	Rat	rn4	UCSC	https://hgdownload.soe.ucsc.edu/goldenPath/rn4/bigZips/rn4.fa.gz	bt2	UCSC rn4
+rnor60	Rnor_6.0	Rat	Rnor6.0	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/895/GCF_000001895.5_Rnor_6.0/GCF_000001895.5_Rnor_6.0_genomic.fna.gz	bt2	RefSeq Rnor_6.0
+grcg6a	GRCg6a	Chicken	GRCg6a	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/002/315/GCF_000002315.6_GRCg6a/GCF_000002315.6_GRCg6a_genomic.fna.gz	bt2	RefSeq GRCg6a
+galgal4	Galgal4	Chicken	Galgal4	Ensembl	https://ftp.ensembl.org/pub/release-84/fasta/gallus_gallus/dna/Gallus_gallus.Galgal4.dna.toplevel.fa.gz	bt2	Ensembl release-84 Galgal4 toplevel
+grcz11	GRCz11	Zebrafish	GRCz11	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/002/035/GCF_000002035.6_GRCz11/GCF_000002035.6_GRCz11_genomic.fna.gz	bt2	RefSeq GRCz11
+grcz10	GRCz10	Zebrafish	GRCz10	Ensembl	https://ftp.ensembl.org/pub/release-80/fasta/danio_rerio/dna/Danio_rerio.GRCz10.dna.toplevel.fa.gz	bt2	Ensembl release-80 GRCz10 toplevel
+agpv4	AGPv4	Corn	AGPv4	Ensembl	https://ftp.ensemblgenomes.ebi.ac.uk/pub/plants/release-40/fasta/zea_mays/dna/Zea_mays.AGPv4.dna.toplevel.fa.gz	bt2	Ensembl Plants release-40 AGPv4
+b73_refgen_v5	Zm-B73-REFERENCE-NAM-5.0	Corn	B73 RefGenV5	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/902/167/145/GCF_902167145.1_Zm-B73-REFERENCE-NAM-5.0/GCF_902167145.1_Zm-B73-REFERENCE-NAM-5.0_genomic.fna.gz	bt2	RefSeq B73 NAM-5.0
+build4	Build_4.0	Oryza sativa (rice)	Build_4.0	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/005/425/GCF_000005425.2_Build_4.0/GCF_000005425.2_Build_4.0_genomic.fna.gz	bt2	RefSeq Build_4.0
+tair10	TAIR10	Arabidopsis thaliana	TAIR10	Ensembl	https://ftp.ensemblgenomes.ebi.ac.uk/pub/plants/release-40/fasta/arabidopsis_thaliana/dna/Arabidopsis_thaliana.TAIR10.dna.toplevel.fa.gz	bt2	Ensembl Plants release-40 TAIR10
+bdgp6	BDGP6	Fruitfly	BDGP6	Ensembl	https://ftp.ensembl.org/pub/release-91/fasta/drosophila_melanogaster/dna/Drosophila_melanogaster.BDGP6.dna.toplevel.fa.gz	bt2	Ensembl release-91 BDGP6 toplevel
+dmela410	Dmel_A4_1.0	Fruitfly	Dmel A4 1.0	NCBI	https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/002/300/595/GCA_002300595.1_Dmel_A4_1.0/GCA_002300595.1_Dmel_A4_1.0_genomic.fna.gz	bt2	GenBank Dmel_A4_1.0
+wbcel235	WBcel235	C. elegans	WBcel235	Ensembl	https://ftp.ensembl.org/pub/release-112/fasta/caenorhabditis_elegans/dna/Caenorhabditis_elegans.WBcel235.dna.toplevel.fa.gz	bt2	Ensembl release-112 WBcel235 toplevel
+r6411	R64-1-1	Yeast	R64-1-1	Ensembl	https://ftp.ensembl.org/pub/release-112/fasta/saccharomyces_cerevisiae/dna/Saccharomyces_cerevisiae.R64-1-1.dna.toplevel.fa.gz	bt2	Ensembl release-112 R64-1-1 toplevel

--- a/build/bowtie/run_legacy_metadata_backfill.bash
+++ b/build/bowtie/run_legacy_metadata_backfill.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run metadata-only backfill for every row in legacy_targets.tsv (requires AWS CLI,
+# samtools, curl, zip, and network access to S3 and FASTA URLs).
+set -euo pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+ids=()
+while IFS=$'\t' read -r id _rest; do
+    [[ -z "${id:-}" || "${id:0:1}" == "#" ]] && continue
+    ids+=("$id")
+done < legacy_targets.tsv
+
+if [[ "${#ids[@]}" -eq 0 ]]; then
+    printf 'error: no target ids found in legacy_targets.tsv\n' >&2
+    exit 1
+fi
+
+exec ./build_indexes.bash --metadata-only --backfill \
+    --from-s3-prefix "${FROM_S3_PREFIX:-s3://genome-idx/bt}" \
+    --targets legacy_targets.tsv \
+    --upload-prefix "${UPLOAD_PREFIX:-s3://genome-idx/bt}" \
+    "${ids[@]}"

--- a/build/bowtie/run_pilot_metadata_backfill.bash
+++ b/build/bowtie/run_pilot_metadata_backfill.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Pilot metadata-only backfill: small genomes (yeast, fruit fly, C. elegans).
+# Requires: samtools, curl, zip, aws (credentials for genome-idx), network.
+set -euo pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+for cmd in samtools curl zip aws; do
+    command -v "$cmd" >/dev/null 2>&1 || {
+        printf 'error: %s not on PATH\n' "$cmd" >&2
+        exit 1
+    }
+done
+
+exec ./build_indexes.bash --metadata-only --backfill \
+    --from-s3-prefix "${FROM_S3_PREFIX:-s3://genome-idx/bt}" \
+    --targets legacy_targets.tsv \
+    --upload-prefix "${UPLOAD_PREFIX:-s3://genome-idx/bt}" \
+    r6411 bdgp6 wbcel235

--- a/build/bowtie/run_resume_missing_metadata_backfill.bash
+++ b/build/bowtie/run_resume_missing_metadata_backfill.bash
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Resume metadata backfill for catalog rows still missing sidecars on S3.
+# Runs one build_indexes.bash invocation per id so a single failure does not stop the batch.
+set -u
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+export AWS_PROFILE="${AWS_PROFILE:-index-zone-s3}"
+log="${RESUME_LOG:-${script_dir}/legacy_backfill_resume.log}"
+
+missing=()
+while IFS=$'\t' read -r status short _rest; do
+    [[ "$status" == MISSING ]] || continue
+    missing+=("$short")
+done < <(python3 audit_s3.py --require-metadata 2>/dev/null || true)
+
+if [[ "${#missing[@]}" -eq 0 ]]; then
+    printf 'No MISSING rows from audit_s3.py; nothing to do.\n' | tee -a "$log"
+    exit 0
+fi
+
+{
+    echo ""
+    echo "=== resume_missing $(date "+%Y-%m-%dT%H:%M:%S%z") count=${#missing[@]} ==="
+    printf 'IDs: %s\n' "${missing[*]}"
+} >>"$log"
+
+ok=0
+fail=0
+for id in "${missing[@]}"; do
+    printf '\n--- %s %s ---\n' "$(date "+%Y-%m-%dT%H:%M:%S%z")" "$id" >>"$log"
+    cmd=(./build_indexes.bash --metadata-only --backfill
+        --from-s3-prefix "${FROM_S3_PREFIX:-s3://genome-idx/bt}"
+        --targets legacy_targets.tsv
+        --upload-prefix "${UPLOAD_PREFIX:-s3://genome-idx/bt}")
+    if [[ "$id" == grch37 ]]; then
+        cmd+=(--force)
+    fi
+    cmd+=("$id")
+    if "${cmd[@]}" >>"$log" 2>&1; then
+        printf 'OK %s\n' "$id" >>"$log"
+        ok=$((ok + 1))
+    else
+        ec=$?
+        printf 'FAIL %s exit=%s\n' "$id" "$ec" >>"$log"
+        fail=$((fail + 1))
+    fi
+done
+
+{
+    echo "=== resume_missing done $(date "+%Y-%m-%dT%H:%M:%S%z") ok=$ok fail=$fail ==="
+    python3 audit_s3.py --require-metadata 2>&1 | awk '/^OK\t|^MISSING\t/' || true
+} >>"$log" 2>&1
+
+exit 0

--- a/build/bowtie/wait_and_audit_legacy_backfill.bash
+++ b/build/bowtie/wait_and_audit_legacy_backfill.bash
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Wait for legacy_backfill_remaining.log to get an EXIT: line (or build_indexes to
+# disappear without EXIT — then annotate), append progress periodically, then run
+# audit_s3.py --require-metadata --strict.  Intended to be started after the main
+# backfill is already running:  nohup ./wait_and_audit_legacy_backfill.bash &
+set -euo pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+log="$script_dir/legacy_backfill_remaining.log"
+watch_log="$script_dir/legacy_backfill_watch.log"
+
+{
+  echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") wait_and_audit started ==="
+  while true; do
+    if [[ -f "$log" ]] && grep -q '^EXIT:' "$log" 2>/dev/null; then
+      echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") saw EXIT in main log ==="
+      grep '^EXIT:' "$log" || true
+      break
+    fi
+    if ! pgrep -f '[b]uild_indexes.bash --metadata-only' >/dev/null 2>&1; then
+      sleep 15
+      if [[ -f "$log" ]] && grep -q '^EXIT:' "$log" 2>/dev/null; then
+        echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") EXIT after process exit ==="
+        break
+      fi
+      echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") build_indexes gone but no EXIT line; check $log ===" >&2
+      break
+    fi
+    n=$(grep -c 'Finished metadata backfill for' "$log" 2>/dev/null || echo 0)
+    echo "$(date "+%Y-%m-%dT%H:%M:%S%z") completed_targets=$n"
+    sleep 300
+  done
+
+  echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") running audit_s3.py --require-metadata --strict ==="
+  cd "$repo_root"
+  AWS_PROFILE="${AWS_PROFILE:-index-zone-s3}" python3 build/bowtie/audit_s3.py --require-metadata --strict || true
+  echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") audit finished (exit above may be non-zero if gaps remain) ==="
+} >>"$watch_log" 2>&1

--- a/docs/bowtie.md
+++ b/docs/bowtie.md
@@ -4,54 +4,54 @@ Bowtie 2 ([GitHub repo](https://github.com/BenLangmead/bowtie2)) and Bowtie ([Gi
 
 In the past, Bowtie 1 & 2 had incompatible genome indexes.  This changed in July 2019 when Bowtie v1.2.3 gained the ability to use Bowtie 2 formatted genome indexes (ending in `.bt2`).  We list only Bowtie 2-format `.bt2` index files here.
 
-You can download all the files for a given assembly as a single `zip` file, or as 6 separate `.bt2` / `.bt2l` files.  For example, if you only need the forward version of the genome index (e.g. for exact matching only), you can download the files individually and omit the `.rev.1.bt2` and `.rev.2.bt2` files.  Downloading already-decompressed index files might also be quicker for applications running in the AWS cloud.  The Metadata column links to the archive MD5 file and, for newer builds, may also include a SAM-style sequence dictionary (`.dict`) and provenance manifest (`.manifest.json`).
+You can download all the files for a given assembly as a single `zip` file, or as 6 separate `.bt2` / `.bt2l` files.  For example, if you only need the forward version of the genome index (e.g. for exact matching only), you can download the files individually and omit the `.rev.1.bt2` and `.rev.2.bt2` files.  Downloading already-decompressed index files might also be quicker for applications running in the AWS cloud.  The Metadata column links to the archive MD5 file, a SAM-style sequence dictionary (`.dict`), and the provenance manifest (`.manifest.json`).
 
 <div class="datatable-begin"></div>
 
 | Species/Build | Source | HTTPS URLs | Metadata |
 | --- | --- | --- | --- |
-| Human / GRCh38 no-alt analysis set | [NCBI][bt2_grch38_noalt_source] | [full zip][bt2_grch38_noalt_full], [.1.bt2][bt2_grch38_noalt_1], [.2.bt2][bt2_grch38_noalt_2], [.3.bt2][bt2_grch38_noalt_3], [.4.bt2][bt2_grch38_noalt_4], [.rev.1.bt2][bt2_grch38_noalt_r1], [.rev.2.bt2][bt2_grch38_noalt_r2] | [archive md5][bt2_grch38_noalt_md5] |
-| Human / GRCh38 no-alt +decoy set | [NCBI][bt2_grch38_noalt_decoy_source] | [full zip][bt2_grch38_noalt_decoy_full], [.1.bt2][bt2_grch38_noalt_decoy_1], [.2.bt2][bt2_grch38_noalt_decoy_2], [.3.bt2][bt2_grch38_noalt_decoy_3], [.4.bt2][bt2_grch38_noalt_decoy_4], [.rev.1.bt2][bt2_grch38_noalt_decoy_r1], [.rev.2.bt2][bt2_grch38_noalt_decoy_r2] | [archive md5][bt2_grch38_noalt_decoy_md5] |
-| Human / GRCh38 + major SNVs | [NCBI+1KG<sup>1</sup>][bt2_grch38_1kgmaj_source] | [full zip][bt2_grch38_1kgmaj_full], [.1.bt2][bt2_grch38_1kgmaj_1], [.2.bt2][bt2_grch38_1kgmaj_2], [.3.bt2][bt2_grch38_1kgmaj_3], [.4.bt2][bt2_grch38_1kgmaj_4], [.rev.1.bt2][bt2_grch38_1kgmaj_r1], [.rev.2.bt2][bt2_grch38_1kgmaj_r2] | [archive md5][bt2_grch38_1kgmaj_md5] |
-| Human / GRCh37 | [NCBI][bt2_grch37_source] | [full zip][bt2_grch37_full], [.1.bt2][bt2_grch37_1], [.2.bt2][bt2_grch37_2], [.3.bt2][bt2_grch37_3], [.4.bt2][bt2_grch37_4], [.rev.1.bt2][bt2_grch37_r1], [.rev.2.bt2][bt2_grch37_r2] | [archive md5][bt2_grch37_md5] |
-| Human / Ash1v1.7 | [JHU <sup>2</sup>][bt2_ash1_source] | [full zip][bt2_ash1_full], [.1.bt2][bt2_ash1_1], [.2.bt2][bt2_ash1_2], [.3.bt2][bt2_ash1_3], [.4.bt2][bt2_ash1_4], [.rev.1.bt2][bt2_ash1_r1], [.rev.2.bt2][bt2_ash1_r2] | [archive md5][bt2_ash1_md5] |
-| Human / Ash1v2.0 | [JHU <sup>2</sup>][bt2_ash1_2_source] | [full zip][bt2_ash1_2_full], [.1.bt2][bt2_ash1_2_1], [.2.bt2][bt2_ash1_2_2], [.3.bt2][bt2_ash1_2_3], [.4.bt2][bt2_ash1_2_4], [.rev.1.bt2][bt2_ash1_2_r1], [.rev.2.bt2][bt2_ash1_2_r2] | [archive md5][bt2_ash1_2_md5] |
-| Human / CHM13plusY | [T2T <sup>3</sup>][bt2_t2tplusy_source] | [full zip][bt2_t2tplusy_full], [.1.bt2][bt2_t2tplusy_1], [.2.bt2][bt2_t2tplusy_2], [.3.bt2][bt2_t2tplusy_3], [.4.bt2][bt2_t2tplusy_4], [.rev.1.bt2][bt2_t2tplusy_r1], [.rev.2.bt2][bt2_t2tplusy_r2] | [archive md5][bt2_t2tplusy_md5] |
+| Human / GRCh38 no-alt analysis set | [NCBI][bt2_grch38_noalt_source] | [full zip][bt2_grch38_noalt_full], [.1.bt2][bt2_grch38_noalt_1], [.2.bt2][bt2_grch38_noalt_2], [.3.bt2][bt2_grch38_noalt_3], [.4.bt2][bt2_grch38_noalt_4], [.rev.1.bt2][bt2_grch38_noalt_r1], [.rev.2.bt2][bt2_grch38_noalt_r2] | [archive md5][bt2_grch38_noalt_md5], [.dict][bt2_grch38_noalt_dict], [manifest json][bt2_grch38_noalt_manifest] |
+| Human / GRCh38 no-alt +decoy set | [NCBI][bt2_grch38_noalt_decoy_source] | [full zip][bt2_grch38_noalt_decoy_full], [.1.bt2][bt2_grch38_noalt_decoy_1], [.2.bt2][bt2_grch38_noalt_decoy_2], [.3.bt2][bt2_grch38_noalt_decoy_3], [.4.bt2][bt2_grch38_noalt_decoy_4], [.rev.1.bt2][bt2_grch38_noalt_decoy_r1], [.rev.2.bt2][bt2_grch38_noalt_decoy_r2] | [archive md5][bt2_grch38_noalt_decoy_md5], [.dict][bt2_grch38_noalt_decoy_dict], [manifest json][bt2_grch38_noalt_decoy_manifest] |
+| Human / GRCh38 + major SNVs | [NCBI+1KG<sup>1</sup>][bt2_grch38_1kgmaj_source] | [full zip][bt2_grch38_1kgmaj_full], [.1.bt2][bt2_grch38_1kgmaj_1], [.2.bt2][bt2_grch38_1kgmaj_2], [.3.bt2][bt2_grch38_1kgmaj_3], [.4.bt2][bt2_grch38_1kgmaj_4], [.rev.1.bt2][bt2_grch38_1kgmaj_r1], [.rev.2.bt2][bt2_grch38_1kgmaj_r2] | [archive md5][bt2_grch38_1kgmaj_md5], [.dict][bt2_grch38_1kgmaj_dict], [manifest json][bt2_grch38_1kgmaj_manifest] |
+| Human / GRCh37 | [NCBI][bt2_grch37_source] | [full zip][bt2_grch37_full], [.1.bt2][bt2_grch37_1], [.2.bt2][bt2_grch37_2], [.3.bt2][bt2_grch37_3], [.4.bt2][bt2_grch37_4], [.rev.1.bt2][bt2_grch37_r1], [.rev.2.bt2][bt2_grch37_r2] | [archive md5][bt2_grch37_md5], [.dict][bt2_grch37_dict], [manifest json][bt2_grch37_manifest] |
+| Human / Ash1v1.7 | [JHU <sup>2</sup>][bt2_ash1_source] | [full zip][bt2_ash1_full], [.1.bt2][bt2_ash1_1], [.2.bt2][bt2_ash1_2], [.3.bt2][bt2_ash1_3], [.4.bt2][bt2_ash1_4], [.rev.1.bt2][bt2_ash1_r1], [.rev.2.bt2][bt2_ash1_r2] | [archive md5][bt2_ash1_md5], [.dict][bt2_ash1_dict], [manifest json][bt2_ash1_manifest] |
+| Human / Ash1v2.0 | [JHU <sup>2</sup>][bt2_ash1_2_source] | [full zip][bt2_ash1_2_full], [.1.bt2][bt2_ash1_2_1], [.2.bt2][bt2_ash1_2_2], [.3.bt2][bt2_ash1_2_3], [.4.bt2][bt2_ash1_2_4], [.rev.1.bt2][bt2_ash1_2_r1], [.rev.2.bt2][bt2_ash1_2_r2] | [archive md5][bt2_ash1_2_md5], [.dict][bt2_ash1_2_dict], [manifest json][bt2_ash1_2_manifest] |
+| Human / CHM13plusY | [T2T <sup>3</sup>][bt2_t2tplusy_source] | [full zip][bt2_t2tplusy_full], [.1.bt2][bt2_t2tplusy_1], [.2.bt2][bt2_t2tplusy_2], [.3.bt2][bt2_t2tplusy_3], [.4.bt2][bt2_t2tplusy_4], [.rev.1.bt2][bt2_t2tplusy_r1], [.rev.2.bt2][bt2_t2tplusy_r2] | [archive md5][bt2_t2tplusy_md5], [.dict][bt2_t2tplusy_dict], [manifest json][bt2_t2tplusy_manifest] |
 | Human / hs1 / T2T-CHM13v2.0 | [UCSC][bt2_hs1_source] | [full zip][bt2_hs1_full], [.1.bt2][bt2_hs1_1], [.2.bt2][bt2_hs1_2], [.3.bt2][bt2_hs1_3], [.4.bt2][bt2_hs1_4], [.rev.1.bt2][bt2_hs1_r1], [.rev.2.bt2][bt2_hs1_r2] | [archive md5][bt2_hs1_md5], [.dict][bt2_hs1_dict], [manifest json][bt2_hs1_manifest] |
-| Human / hg19 | [UCSC][bt2_hg19_source] | [full zip][bt2_hg19_full], [.1.bt2][bt2_hg19_1], [.2.bt2][bt2_hg19_2], [.3.bt2][bt2_hg19_3], [.4.bt2][bt2_hg19_4], [.rev.1.bt2][bt2_hg19_r1], [.rev.2.bt2][bt2_hg19_r2] | [archive md5][bt2_hg19_md5] |
-| Human / hg18 | [UCSC][bt2_hg18_source] | [full zip][bt2_hg18_full], [.1.bt2][bt2_hg18_1], [.2.bt2][bt2_hg18_2], [.3.bt2][bt2_hg18_3], [.4.bt2][bt2_hg18_4], [.rev.1.bt2][bt2_hg18_r1], [.rev.2.bt2][bt2_hg18_r2] | [archive md5][bt2_hg18_md5] |
-| Mouse / GRCm38 | [NCBI][bt2_grcm38_source] | [full zip][bt2_grcm38_full], [.1.bt2][bt2_grcm38_1], [.2.bt2][bt2_grcm38_2], [.3.bt2][bt2_grcm38_3], [.4.bt2][bt2_grcm38_4], [.rev.1.bt2][bt2_grcm38_r1], [.rev.2.bt2][bt2_grcm38_r2] | [archive md5][bt2_grcm38_md5] |
-| Mouse / GRCm39 | [NCBI][bt2_grcm39_source] | [full zip][bt2_grcm39_full], [.1.bt2][bt2_grcm39_1], [.2.bt2][bt2_grcm39_2], [.3.bt2][bt2_grcm39_3], [.4.bt2][bt2_grcm39_4], [.rev.1.bt2][bt2_grcm39_r1], [.rev.2.bt2][bt2_grcm39_r2] | [archive md5][bt2_grcm39_md5] |
-| Mouse / mm10 | [UCSC][bt2_mm10_source] | [full zip][bt2_mm10_full], [.1.bt2][bt2_mm10_1], [.2.bt2][bt2_mm10_2], [.3.bt2][bt2_mm10_3], [.4.bt2][bt2_mm10_4], [.rev.1.bt2][bt2_mm10_r1], [.rev.2.bt2][bt2_mm10_r2] | [archive md5][bt2_mm10_md5] |
-| Mouse / mm9 | [UCSC][bt2_mm9_source] | [full zip][bt2_mm9_full], [.1.bt2][bt2_mm9_1], [.2.bt2][bt2_mm9_2], [.3.bt2][bt2_mm9_3], [.4.bt2][bt2_mm9_4], [.rev.1.bt2][bt2_mm9_r1], [.rev.2.bt2][bt2_mm9_r2] | [archive md5][bt2_mm9_md5] |
-| Chimpanzee / Clint_PTRv2 | [NCBI][bt2_clintptr2_source] | [full zip][bt2_clintptr2_full], [.1.bt2][bt2_clintptr2_1], [.2.bt2][bt2_clintptr2_2], [.3.bt2][bt2_clintptr2_3], [.4.bt2][bt2_clintptr2_4], [.rev.1.bt2][bt2_clintptr2_r1], [.rev.2.bt2][bt2_clintptr2_r2] | [archive md5][bt2_clintptr2_md5] |
-| Chimpanzee / CHIMP2.1.4 | [Ensembl][bt2_chimp214_source] | [full zip][bt2_chimp214_full], [.1.bt2][bt2_chimp214_1], [.2.bt2][bt2_chimp214_2], [.3.bt2][bt2_chimp214_3], [.4.bt2][bt2_chimp214_4], [.rev.1.bt2][bt2_chimp214_r1], [.rev.2.bt2][bt2_chimp214_r2] | [archive md5][bt2_chimp214_md5] |
-| Rhesus macaque / MMul_10 | [Ensembl][bt2_mmul10_source] | [full zip][bt2_mmul10_full], [.1.bt2][bt2_mmul10_1], [.2.bt2][bt2_mmul10_2], [.3.bt2][bt2_mmul10_3], [.4.bt2][bt2_mmul10_4], [.rev.1.bt2][bt2_mmul10_r1], [.rev.2.bt2][bt2_mmul10_r2] | [archive md5][bt2_mmul10_md5] |
+| Human / hg19 | [UCSC][bt2_hg19_source] | [full zip][bt2_hg19_full], [.1.bt2][bt2_hg19_1], [.2.bt2][bt2_hg19_2], [.3.bt2][bt2_hg19_3], [.4.bt2][bt2_hg19_4], [.rev.1.bt2][bt2_hg19_r1], [.rev.2.bt2][bt2_hg19_r2] | [archive md5][bt2_hg19_md5], [.dict][bt2_hg19_dict], [manifest json][bt2_hg19_manifest] |
+| Human / hg18 | [UCSC][bt2_hg18_source] | [full zip][bt2_hg18_full], [.1.bt2][bt2_hg18_1], [.2.bt2][bt2_hg18_2], [.3.bt2][bt2_hg18_3], [.4.bt2][bt2_hg18_4], [.rev.1.bt2][bt2_hg18_r1], [.rev.2.bt2][bt2_hg18_r2] | [archive md5][bt2_hg18_md5], [.dict][bt2_hg18_dict], [manifest json][bt2_hg18_manifest] |
+| Mouse / GRCm38 | [NCBI][bt2_grcm38_source] | [full zip][bt2_grcm38_full], [.1.bt2][bt2_grcm38_1], [.2.bt2][bt2_grcm38_2], [.3.bt2][bt2_grcm38_3], [.4.bt2][bt2_grcm38_4], [.rev.1.bt2][bt2_grcm38_r1], [.rev.2.bt2][bt2_grcm38_r2] | [archive md5][bt2_grcm38_md5], [.dict][bt2_grcm38_dict], [manifest json][bt2_grcm38_manifest] |
+| Mouse / GRCm39 | [NCBI][bt2_grcm39_source] | [full zip][bt2_grcm39_full], [.1.bt2][bt2_grcm39_1], [.2.bt2][bt2_grcm39_2], [.3.bt2][bt2_grcm39_3], [.4.bt2][bt2_grcm39_4], [.rev.1.bt2][bt2_grcm39_r1], [.rev.2.bt2][bt2_grcm39_r2] | [archive md5][bt2_grcm39_md5], [.dict][bt2_grcm39_dict], [manifest json][bt2_grcm39_manifest] |
+| Mouse / mm10 | [UCSC][bt2_mm10_source] | [full zip][bt2_mm10_full], [.1.bt2][bt2_mm10_1], [.2.bt2][bt2_mm10_2], [.3.bt2][bt2_mm10_3], [.4.bt2][bt2_mm10_4], [.rev.1.bt2][bt2_mm10_r1], [.rev.2.bt2][bt2_mm10_r2] | [archive md5][bt2_mm10_md5], [.dict][bt2_mm10_dict], [manifest json][bt2_mm10_manifest] |
+| Mouse / mm9 | [UCSC][bt2_mm9_source] | [full zip][bt2_mm9_full], [.1.bt2][bt2_mm9_1], [.2.bt2][bt2_mm9_2], [.3.bt2][bt2_mm9_3], [.4.bt2][bt2_mm9_4], [.rev.1.bt2][bt2_mm9_r1], [.rev.2.bt2][bt2_mm9_r2] | [archive md5][bt2_mm9_md5], [.dict][bt2_mm9_dict], [manifest json][bt2_mm9_manifest] |
+| Chimpanzee / Clint_PTRv2 | [NCBI][bt2_clintptr2_source] | [full zip][bt2_clintptr2_full], [.1.bt2][bt2_clintptr2_1], [.2.bt2][bt2_clintptr2_2], [.3.bt2][bt2_clintptr2_3], [.4.bt2][bt2_clintptr2_4], [.rev.1.bt2][bt2_clintptr2_r1], [.rev.2.bt2][bt2_clintptr2_r2] | [archive md5][bt2_clintptr2_md5], [.dict][bt2_clintptr2_dict], [manifest json][bt2_clintptr2_manifest] |
+| Chimpanzee / CHIMP2.1.4 | [Ensembl][bt2_chimp214_source] | [full zip][bt2_chimp214_full], [.1.bt2][bt2_chimp214_1], [.2.bt2][bt2_chimp214_2], [.3.bt2][bt2_chimp214_3], [.4.bt2][bt2_chimp214_4], [.rev.1.bt2][bt2_chimp214_r1], [.rev.2.bt2][bt2_chimp214_r2] | [archive md5][bt2_chimp214_md5], [.dict][bt2_chimp214_dict], [manifest json][bt2_chimp214_manifest] |
+| Rhesus macaque / MMul_10 | [Ensembl][bt2_mmul10_source] | [full zip][bt2_mmul10_full], [.1.bt2][bt2_mmul10_1], [.2.bt2][bt2_mmul10_2], [.3.bt2][bt2_mmul10_3], [.4.bt2][bt2_mmul10_4], [.rev.1.bt2][bt2_mmul10_r1], [.rev.2.bt2][bt2_mmul10_r2] | [archive md5][bt2_mmul10_md5], [.dict][bt2_mmul10_dict], [manifest json][bt2_mmul10_manifest] |
 | Cow / ARS-UCD2.0 | [NCBI RefSeq][bt2_arsucd20_source] | [full zip][bt2_arsucd20_full], [.1.bt2][bt2_arsucd20_1], [.2.bt2][bt2_arsucd20_2], [.3.bt2][bt2_arsucd20_3], [.4.bt2][bt2_arsucd20_4], [.rev.1.bt2][bt2_arsucd20_r1], [.rev.2.bt2][bt2_arsucd20_r2] | [archive md5][bt2_arsucd20_md5], [.dict][bt2_arsucd20_dict], [manifest json][bt2_arsucd20_manifest] |
-| Cow / ARS-UCD1.2 | [NCBI][bt2_arsucd12_source] | [full zip][bt2_arsucd12_full], [.1.bt2][bt2_arsucd12_1], [.2.bt2][bt2_arsucd12_2], [.3.bt2][bt2_arsucd12_3], [.4.bt2][bt2_arsucd12_4], [.rev.1.bt2][bt2_arsucd12_r1], [.rev.2.bt2][bt2_arsucd12_r2] | [archive md5][bt2_arsucd12_md5] |
-| Pig / Sscrofa11.1 | [NCBI][bt2_sscorfa111_source] | [full zip][bt2_sscorfa111_full], [.1.bt2][bt2_sscorfa111_1], [.2.bt2][bt2_sscorfa111_2], [.3.bt2][bt2_sscorfa111_3], [.4.bt2][bt2_sscorfa111_4], [.rev.1.bt2][bt2_sscorfa111_r1], [.rev.2.bt2][bt2_sscorfa111_r2] | [archive md5][bt2_sscorfa111_md5] |
+| Cow / ARS-UCD1.2 | [NCBI][bt2_arsucd12_source] | [full zip][bt2_arsucd12_full], [.1.bt2][bt2_arsucd12_1], [.2.bt2][bt2_arsucd12_2], [.3.bt2][bt2_arsucd12_3], [.4.bt2][bt2_arsucd12_4], [.rev.1.bt2][bt2_arsucd12_r1], [.rev.2.bt2][bt2_arsucd12_r2] | [archive md5][bt2_arsucd12_md5], [.dict][bt2_arsucd12_dict], [manifest json][bt2_arsucd12_manifest] |
+| Pig / Sscrofa11.1 | [NCBI][bt2_sscorfa111_source] | [full zip][bt2_sscorfa111_full], [.1.bt2][bt2_sscorfa111_1], [.2.bt2][bt2_sscorfa111_2], [.3.bt2][bt2_sscorfa111_3], [.4.bt2][bt2_sscorfa111_4], [.rev.1.bt2][bt2_sscorfa111_r1], [.rev.2.bt2][bt2_sscorfa111_r2] | [archive md5][bt2_sscorfa111_md5], [.dict][bt2_sscorfa111_dict], [manifest json][bt2_sscorfa111_manifest] |
 | Dog / ROS_Cfam_1.0 | [NCBI RefSeq][bt2_roscfam10_source] | [full zip][bt2_roscfam10_full], [.1.bt2][bt2_roscfam10_1], [.2.bt2][bt2_roscfam10_2], [.3.bt2][bt2_roscfam10_3], [.4.bt2][bt2_roscfam10_4], [.rev.1.bt2][bt2_roscfam10_r1], [.rev.2.bt2][bt2_roscfam10_r2] | [archive md5][bt2_roscfam10_md5], [.dict][bt2_roscfam10_dict], [manifest json][bt2_roscfam10_manifest] |
-| Dog / CanFam3.1 | [Ensembl][bt2_canfam31_source] | [full zip][bt2_canfam31_full], [.1.bt2][bt2_canfam31_1], [.2.bt2][bt2_canfam31_2], [.3.bt2][bt2_canfam31_3], [.4.bt2][bt2_canfam31_4], [.rev.1.bt2][bt2_canfam31_r1], [.rev.2.bt2][bt2_canfam31_r2] | [archive md5][bt2_canfam31_md5] |
-| Dog / CanFam4 | [NCBI][bt2_canfam4_source] | [full zip][bt2_canfam4_full], [.1.bt2][bt2_canfam4_1], [.2.bt2][bt2_canfam4_2], [.3.bt2][bt2_canfam4_3], [.4.bt2][bt2_canfam4_4], [.rev.1.bt2][bt2_canfam4_r1], [.rev.2.bt2][bt2_canfam4_r2] | [archive md5][bt2_canfam4_md5] |
+| Dog / CanFam3.1 | [Ensembl][bt2_canfam31_source] | [full zip][bt2_canfam31_full], [.1.bt2][bt2_canfam31_1], [.2.bt2][bt2_canfam31_2], [.3.bt2][bt2_canfam31_3], [.4.bt2][bt2_canfam31_4], [.rev.1.bt2][bt2_canfam31_r1], [.rev.2.bt2][bt2_canfam31_r2] | [archive md5][bt2_canfam31_md5], [.dict][bt2_canfam31_dict], [manifest json][bt2_canfam31_manifest] |
+| Dog / CanFam4 | [NCBI][bt2_canfam4_source] | [full zip][bt2_canfam4_full], [.1.bt2][bt2_canfam4_1], [.2.bt2][bt2_canfam4_2], [.3.bt2][bt2_canfam4_3], [.4.bt2][bt2_canfam4_4], [.rev.1.bt2][bt2_canfam4_r1], [.rev.2.bt2][bt2_canfam4_r2] | [archive md5][bt2_canfam4_md5], [.dict][bt2_canfam4_dict], [manifest json][bt2_canfam4_manifest] |
 | Rat / GRCr8 | [NCBI RefSeq][bt2_grcr8_source] | [full zip][bt2_grcr8_full], [.1.bt2][bt2_grcr8_1], [.2.bt2][bt2_grcr8_2], [.3.bt2][bt2_grcr8_3], [.4.bt2][bt2_grcr8_4], [.rev.1.bt2][bt2_grcr8_r1], [.rev.2.bt2][bt2_grcr8_r2] | [archive md5][bt2_grcr8_md5], [.dict][bt2_grcr8_dict], [manifest json][bt2_grcr8_manifest] |
-| Rat / rn4 | [UCSC][bt2_rn4_source] | [full zip][bt2_rn4_full], [.1.bt2][bt2_rn4_1], [.2.bt2][bt2_rn4_2], [.3.bt2][bt2_rn4_3], [.4.bt2][bt2_rn4_4], [.rev.1.bt2][bt2_rn4_r1], [.rev.2.bt2][bt2_rn4_r2] | [archive md5][bt2_rn4_md5] |
-| Rat / Rnor6.0 | [NCBI][bt2_rnor60_source] | [full zip][bt2_rnor60_full], [.1.bt2][bt2_rnor60_1], [.2.bt2][bt2_rnor60_2], [.3.bt2][bt2_rnor60_3], [.4.bt2][bt2_rnor60_4], [.rev.1.bt2][bt2_rnor60_r1], [.rev.2.bt2][bt2_rnor60_r2] | [archive md5][bt2_rnor60_md5] |
+| Rat / rn4 | [UCSC][bt2_rn4_source] | [full zip][bt2_rn4_full], [.1.bt2][bt2_rn4_1], [.2.bt2][bt2_rn4_2], [.3.bt2][bt2_rn4_3], [.4.bt2][bt2_rn4_4], [.rev.1.bt2][bt2_rn4_r1], [.rev.2.bt2][bt2_rn4_r2] | [archive md5][bt2_rn4_md5], [.dict][bt2_rn4_dict], [manifest json][bt2_rn4_manifest] |
+| Rat / Rnor6.0 | [NCBI][bt2_rnor60_source] | [full zip][bt2_rnor60_full], [.1.bt2][bt2_rnor60_1], [.2.bt2][bt2_rnor60_2], [.3.bt2][bt2_rnor60_3], [.4.bt2][bt2_rnor60_4], [.rev.1.bt2][bt2_rnor60_r1], [.rev.2.bt2][bt2_rnor60_r2] | [archive md5][bt2_rnor60_md5], [.dict][bt2_rnor60_dict], [manifest json][bt2_rnor60_manifest] |
 | Chicken / bGalGal1.mat.broiler.GRCg7b | [NCBI RefSeq][bt2_grcg7b_source] | [full zip][bt2_grcg7b_full], [.1.bt2][bt2_grcg7b_1], [.2.bt2][bt2_grcg7b_2], [.3.bt2][bt2_grcg7b_3], [.4.bt2][bt2_grcg7b_4], [.rev.1.bt2][bt2_grcg7b_r1], [.rev.2.bt2][bt2_grcg7b_r2] | [archive md5][bt2_grcg7b_md5], [.dict][bt2_grcg7b_dict], [manifest json][bt2_grcg7b_manifest] |
-| Chicken / GRCg6a | [NCBI][bt2_grcg6a_source] | [full zip][bt2_grcg6a_full], [.1.bt2][bt2_grcg6a_1], [.2.bt2][bt2_grcg6a_2], [.3.bt2][bt2_grcg6a_3], [.4.bt2][bt2_grcg6a_4], [.rev.1.bt2][bt2_grcg6a_r1], [.rev.2.bt2][bt2_grcg6a_r2] | [archive md5][bt2_grcg6a_md5] |
-| Chicken / Galgal4 | [Ensembl][bt2_galgal4_source] | [full zip][bt2_galgal4_full], [.1.bt2][bt2_galgal4_1], [.2.bt2][bt2_galgal4_2], [.3.bt2][bt2_galgal4_3], [.4.bt2][bt2_galgal4_4], [.rev.1.bt2][bt2_galgal4_r1], [.rev.2.bt2][bt2_galgal4_r2] | [archive md5][bt2_galgal4_md5] |
-| Zebrafish / GRCz11 | [NCBI][bt2_grcz11_source] | [full zip][bt2_grcz11_full], [.1.bt2][bt2_grcz11_1], [.2.bt2][bt2_grcz11_2], [.3.bt2][bt2_grcz11_3], [.4.bt2][bt2_grcz11_4], [.rev.1.bt2][bt2_grcz11_r1], [.rev.2.bt2][bt2_grcz11_r2] | [archive md5][bt2_grcz11_md5] |
-| Zebrafish / GRCz10 | [NCBI][bt2_grcz10_source] | [full zip][bt2_grcz10_full], [.1.bt2][bt2_grcz10_1], [.2.bt2][bt2_grcz10_2], [.3.bt2][bt2_grcz10_3], [.4.bt2][bt2_grcz10_4], [.rev.1.bt2][bt2_grcz10_r1], [.rev.2.bt2][bt2_grcz10_r2] | [archive md5][bt2_grcz10_md5] |
-| Corn / AGPv4 | [Ensembl][bt2_agpv4_source] | [full zip][bt2_agpv4_full], [.1.bt2][bt2_agpv4_1], [.2.bt2][bt2_agpv4_2], [.3.bt2][bt2_agpv4_3], [.4.bt2][bt2_agpv4_4], [.rev.1.bt2][bt2_agpv4_r1], [.rev.2.bt2][bt2_agpv4_r2] | [archive md5][bt2_agpv4_md5] |
-| Corn / B73 RefGenV5 | [NCBI][bt2_b73_refgen_v5_source] | [full zip][bt2_b73_refgen_v5_full], [.1.bt2][bt2_b73_refgen_v5_1], [.2.bt2][bt2_b73_refgen_v5_2], [.3.bt2][bt2_b73_refgen_v5_3], [.4.bt2][bt2_b73_refgen_v5_4], [.rev.1.bt2][bt2_b73_refgen_v5_r1], [.rev.2.bt2][bt2_b73_refgen_v5_r2] | [archive md5][bt2_b73_refgen_v5_md5] |
+| Chicken / GRCg6a | [NCBI][bt2_grcg6a_source] | [full zip][bt2_grcg6a_full], [.1.bt2][bt2_grcg6a_1], [.2.bt2][bt2_grcg6a_2], [.3.bt2][bt2_grcg6a_3], [.4.bt2][bt2_grcg6a_4], [.rev.1.bt2][bt2_grcg6a_r1], [.rev.2.bt2][bt2_grcg6a_r2] | [archive md5][bt2_grcg6a_md5], [.dict][bt2_grcg6a_dict], [manifest json][bt2_grcg6a_manifest] |
+| Chicken / Galgal4 | [Ensembl][bt2_galgal4_source] | [full zip][bt2_galgal4_full], [.1.bt2][bt2_galgal4_1], [.2.bt2][bt2_galgal4_2], [.3.bt2][bt2_galgal4_3], [.4.bt2][bt2_galgal4_4], [.rev.1.bt2][bt2_galgal4_r1], [.rev.2.bt2][bt2_galgal4_r2] | [archive md5][bt2_galgal4_md5], [.dict][bt2_galgal4_dict], [manifest json][bt2_galgal4_manifest] |
+| Zebrafish / GRCz11 | [NCBI][bt2_grcz11_source] | [full zip][bt2_grcz11_full], [.1.bt2][bt2_grcz11_1], [.2.bt2][bt2_grcz11_2], [.3.bt2][bt2_grcz11_3], [.4.bt2][bt2_grcz11_4], [.rev.1.bt2][bt2_grcz11_r1], [.rev.2.bt2][bt2_grcz11_r2] | [archive md5][bt2_grcz11_md5], [.dict][bt2_grcz11_dict], [manifest json][bt2_grcz11_manifest] |
+| Zebrafish / GRCz10 | [NCBI][bt2_grcz10_source] | [full zip][bt2_grcz10_full], [.1.bt2][bt2_grcz10_1], [.2.bt2][bt2_grcz10_2], [.3.bt2][bt2_grcz10_3], [.4.bt2][bt2_grcz10_4], [.rev.1.bt2][bt2_grcz10_r1], [.rev.2.bt2][bt2_grcz10_r2] | [archive md5][bt2_grcz10_md5], [.dict][bt2_grcz10_dict], [manifest json][bt2_grcz10_manifest] |
+| Corn / AGPv4 | [Ensembl][bt2_agpv4_source] | [full zip][bt2_agpv4_full], [.1.bt2][bt2_agpv4_1], [.2.bt2][bt2_agpv4_2], [.3.bt2][bt2_agpv4_3], [.4.bt2][bt2_agpv4_4], [.rev.1.bt2][bt2_agpv4_r1], [.rev.2.bt2][bt2_agpv4_r2] | [archive md5][bt2_agpv4_md5], [.dict][bt2_agpv4_dict], [manifest json][bt2_agpv4_manifest] |
+| Corn / B73 RefGenV5 | [NCBI][bt2_b73_refgen_v5_source] | [full zip][bt2_b73_refgen_v5_full], [.1.bt2][bt2_b73_refgen_v5_1], [.2.bt2][bt2_b73_refgen_v5_2], [.3.bt2][bt2_b73_refgen_v5_3], [.4.bt2][bt2_b73_refgen_v5_4], [.rev.1.bt2][bt2_b73_refgen_v5_r1], [.rev.2.bt2][bt2_b73_refgen_v5_r2] | [archive md5][bt2_b73_refgen_v5_md5], [.dict][bt2_b73_refgen_v5_dict], [manifest json][bt2_b73_refgen_v5_manifest] |
 | Wheat / IWGSC | [Ensembl Plants][bt2_iwgsc_source] | [full zip][bt2_iwgsc_full], [.1.bt2l][bt2_iwgsc_1], [.2.bt2l][bt2_iwgsc_2], [.3.bt2l][bt2_iwgsc_3], [.4.bt2l][bt2_iwgsc_4], [.rev.1.bt2l][bt2_iwgsc_r1], [.rev.2.bt2l][bt2_iwgsc_r2] | [archive md5][bt2_iwgsc_md5], [.dict][bt2_iwgsc_dict], [manifest json][bt2_iwgsc_manifest] |
 | Barley / MorexV3_pseudomolecules_assembly | [Ensembl Plants][bt2_morexv3_source] | [full zip][bt2_morexv3_full], [.1.bt2l][bt2_morexv3_1], [.2.bt2l][bt2_morexv3_2], [.3.bt2l][bt2_morexv3_3], [.4.bt2l][bt2_morexv3_4], [.rev.1.bt2l][bt2_morexv3_r1], [.rev.2.bt2l][bt2_morexv3_r2] | [archive md5][bt2_morexv3_md5], [.dict][bt2_morexv3_dict], [manifest json][bt2_morexv3_manifest] |
 | Oryza sativa (rice) / IRGSP-1.0 | [Ensembl Plants][bt2_irgsp10_source] | [full zip][bt2_irgsp10_full], [.1.bt2][bt2_irgsp10_1], [.2.bt2][bt2_irgsp10_2], [.3.bt2][bt2_irgsp10_3], [.4.bt2][bt2_irgsp10_4], [.rev.1.bt2][bt2_irgsp10_r1], [.rev.2.bt2][bt2_irgsp10_r2] | [archive md5][bt2_irgsp10_md5], [.dict][bt2_irgsp10_dict], [manifest json][bt2_irgsp10_manifest] |
-| Oryza sativa (rice) / Build_4.0 | [NCBI][bt2_build4_source] | [full zip][bt2_build4_full], [.1.bt2][bt2_build4_1], [.2.bt2][bt2_build4_2], [.3.bt2][bt2_build4_3], [.4.bt2][bt2_build4_4], [.rev.1.bt2][bt2_build4_r1], [.rev.2.bt2][bt2_build4_r2] | [archive md5][bt2_build4_md5] |
-| Arabidopsis thaliana / TAIR10 | [Ensembl][bt2_tair10_source] | [full zip][bt2_tair10_full], [.1.bt2][bt2_tair10_1], [.2.bt2][bt2_tair10_2], [.3.bt2][bt2_tair10_3], [.4.bt2][bt2_tair10_4], [.rev.1.bt2][bt2_tair10_r1], [.rev.2.bt2][bt2_tair10_r2] | [archive md5][bt2_tair10_md5] |
-| Fruitfly / BDGP6 | [Ensembl][bt2_bdgp6_source] | [full zip][bt2_bdgp6_full], [.1.bt2][bt2_bdgp6_1], [.2.bt2][bt2_bdgp6_2], [.3.bt2][bt2_bdgp6_3], [.4.bt2][bt2_bdgp6_4], [.rev.1.bt2][bt2_bdgp6_r1], [.rev.2.bt2][bt2_bdgp6_r2] | [archive md5][bt2_bdgp6_md5] |
-| Fruitfly / Dmel A4 1.0 | [NCBI][bt2_dmela410_source] | [full zip][bt2_dmela410_full], [.1.bt2][bt2_dmela410_1], [.2.bt2][bt2_dmela410_2], [.3.bt2][bt2_dmela410_3], [.4.bt2][bt2_dmela410_4], [.rev.1.bt2][bt2_dmela410_r1], [.rev.2.bt2][bt2_dmela410_r2] | [archive md5][bt2_dmela410_md5] |
-| C. elegans / WBcel235 | [Ensembl][bt2_wbcel235_source] | [full zip][bt2_wbcel235_full], [.1.bt2][bt2_wbcel235_1], [.2.bt2][bt2_wbcel235_2], [.3.bt2][bt2_wbcel235_3], [.4.bt2][bt2_wbcel235_4], [.rev.1.bt2][bt2_wbcel235_r1], [.rev.2.bt2][bt2_wbcel235_r2] | [archive md5][bt2_wbcel235_md5] |
-| Yeast / R64-1-1 | [Ensembl][bt2_r6411_source] | [full zip][bt2_r6411_full], [.1.bt2][bt2_r6411_1], [.2.bt2][bt2_r6411_2], [.3.bt2][bt2_r6411_3], [.4.bt2][bt2_r6411_4], [.rev.1.bt2][bt2_r6411_r1], [.rev.2.bt2][bt2_r6411_r2] | [archive md5][bt2_r6411_md5] |
+| Oryza sativa (rice) / Build_4.0 | [NCBI][bt2_build4_source] | [full zip][bt2_build4_full], [.1.bt2][bt2_build4_1], [.2.bt2][bt2_build4_2], [.3.bt2][bt2_build4_3], [.4.bt2][bt2_build4_4], [.rev.1.bt2][bt2_build4_r1], [.rev.2.bt2][bt2_build4_r2] | [archive md5][bt2_build4_md5], [.dict][bt2_build4_dict], [manifest json][bt2_build4_manifest] |
+| Arabidopsis thaliana / TAIR10 | [Ensembl][bt2_tair10_source] | [full zip][bt2_tair10_full], [.1.bt2][bt2_tair10_1], [.2.bt2][bt2_tair10_2], [.3.bt2][bt2_tair10_3], [.4.bt2][bt2_tair10_4], [.rev.1.bt2][bt2_tair10_r1], [.rev.2.bt2][bt2_tair10_r2] | [archive md5][bt2_tair10_md5], [.dict][bt2_tair10_dict], [manifest json][bt2_tair10_manifest] |
+| Fruitfly / BDGP6 | [Ensembl][bt2_bdgp6_source] | [full zip][bt2_bdgp6_full], [.1.bt2][bt2_bdgp6_1], [.2.bt2][bt2_bdgp6_2], [.3.bt2][bt2_bdgp6_3], [.4.bt2][bt2_bdgp6_4], [.rev.1.bt2][bt2_bdgp6_r1], [.rev.2.bt2][bt2_bdgp6_r2] | [archive md5][bt2_bdgp6_md5], [.dict][bt2_bdgp6_dict], [manifest json][bt2_bdgp6_manifest] |
+| Fruitfly / Dmel A4 1.0 | [NCBI][bt2_dmela410_source] | [full zip][bt2_dmela410_full], [.1.bt2][bt2_dmela410_1], [.2.bt2][bt2_dmela410_2], [.3.bt2][bt2_dmela410_3], [.4.bt2][bt2_dmela410_4], [.rev.1.bt2][bt2_dmela410_r1], [.rev.2.bt2][bt2_dmela410_r2] | [archive md5][bt2_dmela410_md5], [.dict][bt2_dmela410_dict], [manifest json][bt2_dmela410_manifest] |
+| C. elegans / WBcel235 | [Ensembl][bt2_wbcel235_source] | [full zip][bt2_wbcel235_full], [.1.bt2][bt2_wbcel235_1], [.2.bt2][bt2_wbcel235_2], [.3.bt2][bt2_wbcel235_3], [.4.bt2][bt2_wbcel235_4], [.rev.1.bt2][bt2_wbcel235_r1], [.rev.2.bt2][bt2_wbcel235_r2] | [archive md5][bt2_wbcel235_md5], [.dict][bt2_wbcel235_dict], [manifest json][bt2_wbcel235_manifest] |
+| Yeast / R64-1-1 | [Ensembl][bt2_r6411_source] | [full zip][bt2_r6411_full], [.1.bt2][bt2_r6411_1], [.2.bt2][bt2_r6411_2], [.3.bt2][bt2_r6411_3], [.4.bt2][bt2_r6411_4], [.rev.1.bt2][bt2_r6411_r1], [.rev.2.bt2][bt2_r6411_r2] | [archive md5][bt2_r6411_md5], [.dict][bt2_r6411_dict], [manifest json][bt2_r6411_manifest] |
 
 <div class="datatable-end"></div>
 
@@ -128,6 +128,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_grch38_noalt_r1]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_as.rev.1.bt2
 [bt2_grch38_noalt_r2]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_as.rev.2.bt2
 [bt2_grch38_noalt_md5]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_as.md5
+[bt2_grch38_noalt_dict]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_as.dict
+[bt2_grch38_noalt_manifest]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_as.manifest.json
 [bt2_grch38_noalt_decoy_full]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_decoy_as.zip
 [bt2_grch38_noalt_decoy_1]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_decoy_as.1.bt2
 [bt2_grch38_noalt_decoy_2]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_decoy_as.2.bt2
@@ -136,6 +138,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_grch38_noalt_decoy_r1]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_decoy_as.rev.1.bt2
 [bt2_grch38_noalt_decoy_r2]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_decoy_as.rev.2.bt2
 [bt2_grch38_noalt_decoy_md5]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_decoy_as.md5
+[bt2_grch38_noalt_decoy_dict]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_decoy_as.dict
+[bt2_grch38_noalt_decoy_manifest]: https://genome-idx.s3.amazonaws.com/bt/GRCh38_noalt_decoy_as.manifest.json
 [bt2_grch38_1kgmaj_full]: https://genome-idx.s3.amazonaws.com/bt/grch38_1kgmaj.zip
 [bt2_grch38_1kgmaj_1]: https://genome-idx.s3.amazonaws.com/bt/grch38_1kgmaj.1.bt2
 [bt2_grch38_1kgmaj_2]: https://genome-idx.s3.amazonaws.com/bt/grch38_1kgmaj.2.bt2
@@ -144,6 +148,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_grch38_1kgmaj_r1]: https://genome-idx.s3.amazonaws.com/bt/grch38_1kgmaj.rev.1.bt2
 [bt2_grch38_1kgmaj_r2]: https://genome-idx.s3.amazonaws.com/bt/grch38_1kgmaj.rev.2.bt2
 [bt2_grch38_1kgmaj_md5]: https://genome-idx.s3.amazonaws.com/bt/grch38_1kgmaj.md5
+[bt2_grch38_1kgmaj_dict]: https://genome-idx.s3.amazonaws.com/bt/grch38_1kgmaj.dict
+[bt2_grch38_1kgmaj_manifest]: https://genome-idx.s3.amazonaws.com/bt/grch38_1kgmaj.manifest.json
 [bt2_grch37_full]: https://genome-idx.s3.amazonaws.com/bt/GRCh37.zip
 [bt2_grch37_1]: https://genome-idx.s3.amazonaws.com/bt/GRCh37.1.bt2
 [bt2_grch37_2]: https://genome-idx.s3.amazonaws.com/bt/GRCh37.2.bt2
@@ -152,6 +158,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_grch37_r1]: https://genome-idx.s3.amazonaws.com/bt/GRCh37.rev.1.bt2
 [bt2_grch37_r2]: https://genome-idx.s3.amazonaws.com/bt/GRCh37.rev.2.bt2
 [bt2_grch37_md5]: https://genome-idx.s3.amazonaws.com/bt/GRCh37.md5
+[bt2_grch37_dict]: https://genome-idx.s3.amazonaws.com/bt/GRCh37.dict
+[bt2_grch37_manifest]: https://genome-idx.s3.amazonaws.com/bt/GRCh37.manifest.json
 [bt2_ash1_full]: https://genome-idx.s3.amazonaws.com/bt/Ash1v1.7.zip
 [bt2_ash1_1]: https://genome-idx.s3.amazonaws.com/bt/Ash1v1.7.1.bt2
 [bt2_ash1_2]: https://genome-idx.s3.amazonaws.com/bt/Ash1v1.7.2.bt2
@@ -160,6 +168,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_ash1_r1]: https://genome-idx.s3.amazonaws.com/bt/Ash1v1.7.rev.1.bt2
 [bt2_ash1_r2]: https://genome-idx.s3.amazonaws.com/bt/Ash1v1.7.rev.2.bt2
 [bt2_ash1_md5]: https://genome-idx.s3.amazonaws.com/bt/Ash1v1.7.md5
+[bt2_ash1_dict]: https://genome-idx.s3.amazonaws.com/bt/Ash1v1.7.dict
+[bt2_ash1_manifest]: https://genome-idx.s3.amazonaws.com/bt/Ash1v1.7.manifest.json
 [bt2_ash1_2_full]: https://genome-idx.s3.amazonaws.com/bt/Ash1_v2.0.zip
 [bt2_ash1_2_1]: https://genome-idx.s3.amazonaws.com/bt/Ash1_v2.0.1.bt2
 [bt2_ash1_2_2]: https://genome-idx.s3.amazonaws.com/bt/Ash1_v2.0.2.bt2
@@ -168,6 +178,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_ash1_2_r1]: https://genome-idx.s3.amazonaws.com/bt/Ash1_v2.0.rev.1.bt2
 [bt2_ash1_2_r2]: https://genome-idx.s3.amazonaws.com/bt/Ash1_v2.0.rev.2.bt2
 [bt2_ash1_2_md5]: https://genome-idx.s3.amazonaws.com/bt/Ash1_v2.0.md5
+[bt2_ash1_2_dict]: https://genome-idx.s3.amazonaws.com/bt/Ash1_v2.0.dict
+[bt2_ash1_2_manifest]: https://genome-idx.s3.amazonaws.com/bt/Ash1_v2.0.manifest.json
 [bt2_t2tplusy_full]: https://genome-idx.s3.amazonaws.com/bt/chm13.draft_v1.0_plusY.zip
 [bt2_t2tplusy_1]: https://genome-idx.s3.amazonaws.com/bt/chm13.draft_v1.0_plusY.1.bt2
 [bt2_t2tplusy_2]: https://genome-idx.s3.amazonaws.com/bt/chm13.draft_v1.0_plusY.2.bt2
@@ -176,6 +188,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_t2tplusy_r1]: https://genome-idx.s3.amazonaws.com/bt/chm13.draft_v1.0_plusY.rev.1.bt2
 [bt2_t2tplusy_r2]: https://genome-idx.s3.amazonaws.com/bt/chm13.draft_v1.0_plusY.rev.2.bt2
 [bt2_t2tplusy_md5]: https://genome-idx.s3.amazonaws.com/bt/chm13.draft_v1.0_plusY.md5
+[bt2_t2tplusy_dict]: https://genome-idx.s3.amazonaws.com/bt/chm13.draft_v1.0_plusY.dict
+[bt2_t2tplusy_manifest]: https://genome-idx.s3.amazonaws.com/bt/chm13.draft_v1.0_plusY.manifest.json
 [bt2_hs1_full]: https://genome-idx.s3.amazonaws.com/bt/hs1.zip
 [bt2_hs1_1]: https://genome-idx.s3.amazonaws.com/bt/hs1.1.bt2
 [bt2_hs1_2]: https://genome-idx.s3.amazonaws.com/bt/hs1.2.bt2
@@ -194,6 +208,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_hg19_r1]: https://genome-idx.s3.amazonaws.com/bt/hg19.rev.1.bt2
 [bt2_hg19_r2]: https://genome-idx.s3.amazonaws.com/bt/hg19.rev.2.bt2
 [bt2_hg19_md5]: https://genome-idx.s3.amazonaws.com/bt/hg19.md5
+[bt2_hg19_dict]: https://genome-idx.s3.amazonaws.com/bt/hg19.dict
+[bt2_hg19_manifest]: https://genome-idx.s3.amazonaws.com/bt/hg19.manifest.json
 [bt2_hg18_full]: https://genome-idx.s3.amazonaws.com/bt/hg18.zip
 [bt2_hg18_1]: https://genome-idx.s3.amazonaws.com/bt/hg18.1.bt2
 [bt2_hg18_2]: https://genome-idx.s3.amazonaws.com/bt/hg18.2.bt2
@@ -202,6 +218,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_hg18_r1]: https://genome-idx.s3.amazonaws.com/bt/hg18.rev.1.bt2
 [bt2_hg18_r2]: https://genome-idx.s3.amazonaws.com/bt/hg18.rev.2.bt2
 [bt2_hg18_md5]: https://genome-idx.s3.amazonaws.com/bt/hg18.md5
+[bt2_hg18_dict]: https://genome-idx.s3.amazonaws.com/bt/hg18.dict
+[bt2_hg18_manifest]: https://genome-idx.s3.amazonaws.com/bt/hg18.manifest.json
 [bt2_grcm38_full]: https://genome-idx.s3.amazonaws.com/bt/GRCm38.zip
 [bt2_grcm38_1]: https://genome-idx.s3.amazonaws.com/bt/GRCm38.1.bt2
 [bt2_grcm38_2]: https://genome-idx.s3.amazonaws.com/bt/GRCm38.2.bt2
@@ -210,6 +228,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_grcm38_r1]: https://genome-idx.s3.amazonaws.com/bt/GRCm38.rev.1.bt2
 [bt2_grcm38_r2]: https://genome-idx.s3.amazonaws.com/bt/GRCm38.rev.2.bt2
 [bt2_grcm38_md5]: https://genome-idx.s3.amazonaws.com/bt/GRCm38.md5
+[bt2_grcm38_dict]: https://genome-idx.s3.amazonaws.com/bt/GRCm38.dict
+[bt2_grcm38_manifest]: https://genome-idx.s3.amazonaws.com/bt/GRCm38.manifest.json
 [bt2_grcm39_full]: https://genome-idx.s3.amazonaws.com/bt/GRCm39.zip
 [bt2_grcm39_1]: https://genome-idx.s3.amazonaws.com/bt/GRCm39.1.bt2
 [bt2_grcm39_2]: https://genome-idx.s3.amazonaws.com/bt/GRCm39.2.bt2
@@ -218,6 +238,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_grcm39_r1]: https://genome-idx.s3.amazonaws.com/bt/GRCm39.rev.1.bt2
 [bt2_grcm39_r2]: https://genome-idx.s3.amazonaws.com/bt/GRCm39.rev.2.bt2
 [bt2_grcm39_md5]: https://genome-idx.s3.amazonaws.com/bt/GRCm39.md5
+[bt2_grcm39_dict]: https://genome-idx.s3.amazonaws.com/bt/GRCm39.dict
+[bt2_grcm39_manifest]: https://genome-idx.s3.amazonaws.com/bt/GRCm39.manifest.json
 [bt2_mm10_full]: https://genome-idx.s3.amazonaws.com/bt/mm10.zip
 [bt2_mm10_1]: https://genome-idx.s3.amazonaws.com/bt/mm10.1.bt2
 [bt2_mm10_2]: https://genome-idx.s3.amazonaws.com/bt/mm10.2.bt2
@@ -226,6 +248,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_mm10_r1]: https://genome-idx.s3.amazonaws.com/bt/mm10.rev.1.bt2
 [bt2_mm10_r2]: https://genome-idx.s3.amazonaws.com/bt/mm10.rev.2.bt2
 [bt2_mm10_md5]: https://genome-idx.s3.amazonaws.com/bt/mm10.md5
+[bt2_mm10_dict]: https://genome-idx.s3.amazonaws.com/bt/mm10.dict
+[bt2_mm10_manifest]: https://genome-idx.s3.amazonaws.com/bt/mm10.manifest.json
 [bt2_mm9_full]: https://genome-idx.s3.amazonaws.com/bt/mm9.zip
 [bt2_mm9_1]: https://genome-idx.s3.amazonaws.com/bt/mm9.1.bt2
 [bt2_mm9_2]: https://genome-idx.s3.amazonaws.com/bt/mm9.2.bt2
@@ -234,6 +258,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_mm9_r1]: https://genome-idx.s3.amazonaws.com/bt/mm9.rev.1.bt2
 [bt2_mm9_r2]: https://genome-idx.s3.amazonaws.com/bt/mm9.rev.2.bt2
 [bt2_mm9_md5]: https://genome-idx.s3.amazonaws.com/bt/mm9.md5
+[bt2_mm9_dict]: https://genome-idx.s3.amazonaws.com/bt/mm9.dict
+[bt2_mm9_manifest]: https://genome-idx.s3.amazonaws.com/bt/mm9.manifest.json
 [bt2_clintptr2_full]: https://genome-idx.s3.amazonaws.com/bt/Clint_PTRv2.zip
 [bt2_clintptr2_1]: https://genome-idx.s3.amazonaws.com/bt/Clint_PTRv2.1.bt2
 [bt2_clintptr2_2]: https://genome-idx.s3.amazonaws.com/bt/Clint_PTRv2.2.bt2
@@ -242,6 +268,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_clintptr2_r1]: https://genome-idx.s3.amazonaws.com/bt/Clint_PTRv2.rev.1.bt2
 [bt2_clintptr2_r2]: https://genome-idx.s3.amazonaws.com/bt/Clint_PTRv2.rev.2.bt2
 [bt2_clintptr2_md5]: https://genome-idx.s3.amazonaws.com/bt/Clint_PTRv2.md5
+[bt2_clintptr2_dict]: https://genome-idx.s3.amazonaws.com/bt/Clint_PTRv2.dict
+[bt2_clintptr2_manifest]: https://genome-idx.s3.amazonaws.com/bt/Clint_PTRv2.manifest.json
 [bt2_chimp214_full]: https://genome-idx.s3.amazonaws.com/bt/CHIMP2.1.4.zip
 [bt2_chimp214_1]: https://genome-idx.s3.amazonaws.com/bt/CHIMP2.1.4.1.bt2
 [bt2_chimp214_2]: https://genome-idx.s3.amazonaws.com/bt/CHIMP2.1.4.2.bt2
@@ -250,6 +278,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_chimp214_r1]: https://genome-idx.s3.amazonaws.com/bt/CHIMP2.1.4.rev.1.bt2
 [bt2_chimp214_r2]: https://genome-idx.s3.amazonaws.com/bt/CHIMP2.1.4.rev.2.bt2
 [bt2_chimp214_md5]: https://genome-idx.s3.amazonaws.com/bt/CHIMP2.1.4.md5
+[bt2_chimp214_dict]: https://genome-idx.s3.amazonaws.com/bt/CHIMP2.1.4.dict
+[bt2_chimp214_manifest]: https://genome-idx.s3.amazonaws.com/bt/CHIMP2.1.4.manifest.json
 [bt2_mmul10_full]: https://genome-idx.s3.amazonaws.com/bt/Mmul_10.zip
 [bt2_mmul10_1]: https://genome-idx.s3.amazonaws.com/bt/Mmul_10.1.bt2
 [bt2_mmul10_2]: https://genome-idx.s3.amazonaws.com/bt/Mmul_10.2.bt2
@@ -258,6 +288,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_mmul10_r1]: https://genome-idx.s3.amazonaws.com/bt/Mmul_10.rev.1.bt2
 [bt2_mmul10_r2]: https://genome-idx.s3.amazonaws.com/bt/Mmul_10.rev.2.bt2
 [bt2_mmul10_md5]: https://genome-idx.s3.amazonaws.com/bt/Mmul_10.md5
+[bt2_mmul10_dict]: https://genome-idx.s3.amazonaws.com/bt/Mmul_10.dict
+[bt2_mmul10_manifest]: https://genome-idx.s3.amazonaws.com/bt/Mmul_10.manifest.json
 [bt2_arsucd20_full]: https://genome-idx.s3.amazonaws.com/bt/ARS-UCD2.0.zip
 [bt2_arsucd20_1]: https://genome-idx.s3.amazonaws.com/bt/ARS-UCD2.0.1.bt2
 [bt2_arsucd20_2]: https://genome-idx.s3.amazonaws.com/bt/ARS-UCD2.0.2.bt2
@@ -276,6 +308,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_arsucd12_r1]: https://genome-idx.s3.amazonaws.com/bt/ARS-UCD1.2.rev.1.bt2
 [bt2_arsucd12_r2]: https://genome-idx.s3.amazonaws.com/bt/ARS-UCD1.2.rev.2.bt2
 [bt2_arsucd12_md5]: https://genome-idx.s3.amazonaws.com/bt/ARS-UCD1.2.md5
+[bt2_arsucd12_dict]: https://genome-idx.s3.amazonaws.com/bt/ARS-UCD1.2.dict
+[bt2_arsucd12_manifest]: https://genome-idx.s3.amazonaws.com/bt/ARS-UCD1.2.manifest.json
 [bt2_sscorfa111_full]: https://genome-idx.s3.amazonaws.com/bt/Sscrofa11.1.zip
 [bt2_sscorfa111_1]: https://genome-idx.s3.amazonaws.com/bt/Sscrofa11.1.1.bt2
 [bt2_sscorfa111_2]: https://genome-idx.s3.amazonaws.com/bt/Sscrofa11.1.2.bt2
@@ -284,6 +318,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_sscorfa111_r1]: https://genome-idx.s3.amazonaws.com/bt/Sscrofa11.1.rev.1.bt2
 [bt2_sscorfa111_r2]: https://genome-idx.s3.amazonaws.com/bt/Sscrofa11.1.rev.2.bt2
 [bt2_sscorfa111_md5]: https://genome-idx.s3.amazonaws.com/bt/Sscrofa11.1.md5
+[bt2_sscorfa111_dict]: https://genome-idx.s3.amazonaws.com/bt/Sscrofa11.1.dict
+[bt2_sscorfa111_manifest]: https://genome-idx.s3.amazonaws.com/bt/Sscrofa11.1.manifest.json
 [bt2_roscfam10_full]: https://genome-idx.s3.amazonaws.com/bt/ROS_Cfam_1.0.zip
 [bt2_roscfam10_1]: https://genome-idx.s3.amazonaws.com/bt/ROS_Cfam_1.0.1.bt2
 [bt2_roscfam10_2]: https://genome-idx.s3.amazonaws.com/bt/ROS_Cfam_1.0.2.bt2
@@ -302,6 +338,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_canfam31_r1]: https://genome-idx.s3.amazonaws.com/bt/CanFam3.1.rev.1.bt2
 [bt2_canfam31_r2]: https://genome-idx.s3.amazonaws.com/bt/CanFam3.1.rev.2.bt2
 [bt2_canfam31_md5]: https://genome-idx.s3.amazonaws.com/bt/CanFam3.1.md5
+[bt2_canfam31_dict]: https://genome-idx.s3.amazonaws.com/bt/CanFam3.1.dict
+[bt2_canfam31_manifest]: https://genome-idx.s3.amazonaws.com/bt/CanFam3.1.manifest.json
 [bt2_canfam4_full]: https://genome-idx.s3.amazonaws.com/bt/canfam4.zip
 [bt2_canfam4_1]: https://genome-idx.s3.amazonaws.com/bt/canfam4.1.bt2
 [bt2_canfam4_2]: https://genome-idx.s3.amazonaws.com/bt/canfam4.2.bt2
@@ -310,6 +348,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_canfam4_r1]: https://genome-idx.s3.amazonaws.com/bt/canfam4.rev.1.bt2
 [bt2_canfam4_r2]: https://genome-idx.s3.amazonaws.com/bt/canfam4.rev.2.bt2
 [bt2_canfam4_md5]: https://genome-idx.s3.amazonaws.com/bt/canfam4.md5
+[bt2_canfam4_dict]: https://genome-idx.s3.amazonaws.com/bt/canfam4.dict
+[bt2_canfam4_manifest]: https://genome-idx.s3.amazonaws.com/bt/canfam4.manifest.json
 [bt2_grcr8_full]: https://genome-idx.s3.amazonaws.com/bt/GRCr8.zip
 [bt2_grcr8_1]: https://genome-idx.s3.amazonaws.com/bt/GRCr8.1.bt2
 [bt2_grcr8_2]: https://genome-idx.s3.amazonaws.com/bt/GRCr8.2.bt2
@@ -328,6 +368,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_rn4_r1]: https://genome-idx.s3.amazonaws.com/bt/rn4.rev.1.bt2
 [bt2_rn4_r2]: https://genome-idx.s3.amazonaws.com/bt/rn4.rev.2.bt2
 [bt2_rn4_md5]: https://genome-idx.s3.amazonaws.com/bt/rn4.md5
+[bt2_rn4_dict]: https://genome-idx.s3.amazonaws.com/bt/rn4.dict
+[bt2_rn4_manifest]: https://genome-idx.s3.amazonaws.com/bt/rn4.manifest.json
 [bt2_rnor60_full]: https://genome-idx.s3.amazonaws.com/bt/Rnor_6.0.zip
 [bt2_rnor60_1]: https://genome-idx.s3.amazonaws.com/bt/Rnor_6.0.1.bt2
 [bt2_rnor60_2]: https://genome-idx.s3.amazonaws.com/bt/Rnor_6.0.2.bt2
@@ -336,6 +378,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_rnor60_r1]: https://genome-idx.s3.amazonaws.com/bt/Rnor_6.0.rev.1.bt2
 [bt2_rnor60_r2]: https://genome-idx.s3.amazonaws.com/bt/Rnor_6.0.rev.2.bt2
 [bt2_rnor60_md5]: https://genome-idx.s3.amazonaws.com/bt/Rnor_6.0.md5
+[bt2_rnor60_dict]: https://genome-idx.s3.amazonaws.com/bt/Rnor_6.0.dict
+[bt2_rnor60_manifest]: https://genome-idx.s3.amazonaws.com/bt/Rnor_6.0.manifest.json
 [bt2_grcg7b_full]: https://genome-idx.s3.amazonaws.com/bt/bGalGal1.mat.broiler.GRCg7b.zip
 [bt2_grcg7b_1]: https://genome-idx.s3.amazonaws.com/bt/bGalGal1.mat.broiler.GRCg7b.1.bt2
 [bt2_grcg7b_2]: https://genome-idx.s3.amazonaws.com/bt/bGalGal1.mat.broiler.GRCg7b.2.bt2
@@ -354,6 +398,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_grcg6a_r1]: https://genome-idx.s3.amazonaws.com/bt/GRCg6a.rev.1.bt2
 [bt2_grcg6a_r2]: https://genome-idx.s3.amazonaws.com/bt/GRCg6a.rev.2.bt2
 [bt2_grcg6a_md5]: https://genome-idx.s3.amazonaws.com/bt/GRCg6a.md5
+[bt2_grcg6a_dict]: https://genome-idx.s3.amazonaws.com/bt/GRCg6a.dict
+[bt2_grcg6a_manifest]: https://genome-idx.s3.amazonaws.com/bt/GRCg6a.manifest.json
 [bt2_galgal4_full]: https://genome-idx.s3.amazonaws.com/bt/Galgal4.zip
 [bt2_galgal4_1]: https://genome-idx.s3.amazonaws.com/bt/Galgal4.1.bt2
 [bt2_galgal4_2]: https://genome-idx.s3.amazonaws.com/bt/Galgal4.2.bt2
@@ -362,6 +408,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_galgal4_r1]: https://genome-idx.s3.amazonaws.com/bt/Galgal4.rev.1.bt2
 [bt2_galgal4_r2]: https://genome-idx.s3.amazonaws.com/bt/Galgal4.rev.2.bt2
 [bt2_galgal4_md5]: https://genome-idx.s3.amazonaws.com/bt/Galgal4.md5
+[bt2_galgal4_dict]: https://genome-idx.s3.amazonaws.com/bt/Galgal4.dict
+[bt2_galgal4_manifest]: https://genome-idx.s3.amazonaws.com/bt/Galgal4.manifest.json
 [bt2_grcz11_full]: https://genome-idx.s3.amazonaws.com/bt/GRCz11.zip
 [bt2_grcz11_1]: https://genome-idx.s3.amazonaws.com/bt/GRCz11.1.bt2
 [bt2_grcz11_2]: https://genome-idx.s3.amazonaws.com/bt/GRCz11.2.bt2
@@ -370,6 +418,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_grcz11_r1]: https://genome-idx.s3.amazonaws.com/bt/GRCz11.rev.1.bt2
 [bt2_grcz11_r2]: https://genome-idx.s3.amazonaws.com/bt/GRCz11.rev.2.bt2
 [bt2_grcz11_md5]: https://genome-idx.s3.amazonaws.com/bt/GRCz11.md5
+[bt2_grcz11_dict]: https://genome-idx.s3.amazonaws.com/bt/GRCz11.dict
+[bt2_grcz11_manifest]: https://genome-idx.s3.amazonaws.com/bt/GRCz11.manifest.json
 [bt2_grcz10_full]: https://genome-idx.s3.amazonaws.com/bt/GRCz10.zip
 [bt2_grcz10_1]: https://genome-idx.s3.amazonaws.com/bt/GRCz10.1.bt2
 [bt2_grcz10_2]: https://genome-idx.s3.amazonaws.com/bt/GRCz10.2.bt2
@@ -378,6 +428,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_grcz10_r1]: https://genome-idx.s3.amazonaws.com/bt/GRCz10.rev.1.bt2
 [bt2_grcz10_r2]: https://genome-idx.s3.amazonaws.com/bt/GRCz10.rev.2.bt2
 [bt2_grcz10_md5]: https://genome-idx.s3.amazonaws.com/bt/GRCz10.md5
+[bt2_grcz10_dict]: https://genome-idx.s3.amazonaws.com/bt/GRCz10.dict
+[bt2_grcz10_manifest]: https://genome-idx.s3.amazonaws.com/bt/GRCz10.manifest.json
 [bt2_agpv4_full]: https://genome-idx.s3.amazonaws.com/bt/AGPv4.zip
 [bt2_agpv4_1]: https://genome-idx.s3.amazonaws.com/bt/AGPv4.1.bt2
 [bt2_agpv4_2]: https://genome-idx.s3.amazonaws.com/bt/AGPv4.2.bt2
@@ -386,6 +438,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_agpv4_r1]: https://genome-idx.s3.amazonaws.com/bt/AGPv4.rev.1.bt2
 [bt2_agpv4_r2]: https://genome-idx.s3.amazonaws.com/bt/AGPv4.rev.2.bt2
 [bt2_agpv4_md5]: https://genome-idx.s3.amazonaws.com/bt/AGPv4.md5
+[bt2_agpv4_dict]: https://genome-idx.s3.amazonaws.com/bt/AGPv4.dict
+[bt2_agpv4_manifest]: https://genome-idx.s3.amazonaws.com/bt/AGPv4.manifest.json
 [bt2_b73_refgen_v5_full]: https://genome-idx.s3.amazonaws.com/bt/Zm-B73-REFERENCE-NAM-5.0.zip
 [bt2_b73_refgen_v5_1]: https://genome-idx.s3.amazonaws.com/bt/Zm-B73-REFERENCE-NAM-5.0.1.bt2
 [bt2_b73_refgen_v5_2]: https://genome-idx.s3.amazonaws.com/bt/Zm-B73-REFERENCE-NAM-5.0.2.bt2
@@ -394,6 +448,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_b73_refgen_v5_r1]: https://genome-idx.s3.amazonaws.com/bt/Zm-B73-REFERENCE-NAM-5.0.rev.1.bt2
 [bt2_b73_refgen_v5_r2]: https://genome-idx.s3.amazonaws.com/bt/Zm-B73-REFERENCE-NAM-5.0.rev.2.bt2
 [bt2_b73_refgen_v5_md5]: https://genome-idx.s3.amazonaws.com/bt/Zm-B73-REFERENCE-NAM-5.0.md5
+[bt2_b73_refgen_v5_dict]: https://genome-idx.s3.amazonaws.com/bt/Zm-B73-REFERENCE-NAM-5.0.dict
+[bt2_b73_refgen_v5_manifest]: https://genome-idx.s3.amazonaws.com/bt/Zm-B73-REFERENCE-NAM-5.0.manifest.json
 [bt2_iwgsc_full]: https://genome-idx.s3.amazonaws.com/bt/IWGSC.zip
 [bt2_iwgsc_1]: https://genome-idx.s3.amazonaws.com/bt/IWGSC.1.bt2l
 [bt2_iwgsc_2]: https://genome-idx.s3.amazonaws.com/bt/IWGSC.2.bt2l
@@ -432,6 +488,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_build4_r1]: https://genome-idx.s3.amazonaws.com/bt/Build_4.0.rev.1.bt2
 [bt2_build4_r2]: https://genome-idx.s3.amazonaws.com/bt/Build_4.0.rev.2.bt2
 [bt2_build4_md5]: https://genome-idx.s3.amazonaws.com/bt/Build_4.0.md5
+[bt2_build4_dict]: https://genome-idx.s3.amazonaws.com/bt/Build_4.0.dict
+[bt2_build4_manifest]: https://genome-idx.s3.amazonaws.com/bt/Build_4.0.manifest.json
 [bt2_tair10_full]: https://genome-idx.s3.amazonaws.com/bt/TAIR10.zip
 [bt2_tair10_1]: https://genome-idx.s3.amazonaws.com/bt/TAIR10.1.bt2
 [bt2_tair10_2]: https://genome-idx.s3.amazonaws.com/bt/TAIR10.2.bt2
@@ -440,6 +498,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_tair10_r1]: https://genome-idx.s3.amazonaws.com/bt/TAIR10.rev.1.bt2
 [bt2_tair10_r2]: https://genome-idx.s3.amazonaws.com/bt/TAIR10.rev.2.bt2
 [bt2_tair10_md5]: https://genome-idx.s3.amazonaws.com/bt/TAIR10.md5
+[bt2_tair10_dict]: https://genome-idx.s3.amazonaws.com/bt/TAIR10.dict
+[bt2_tair10_manifest]: https://genome-idx.s3.amazonaws.com/bt/TAIR10.manifest.json
 [bt2_bdgp6_full]: https://genome-idx.s3.amazonaws.com/bt/BDGP6.zip
 [bt2_bdgp6_1]: https://genome-idx.s3.amazonaws.com/bt/BDGP6.1.bt2
 [bt2_bdgp6_2]: https://genome-idx.s3.amazonaws.com/bt/BDGP6.2.bt2
@@ -448,6 +508,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_bdgp6_r1]: https://genome-idx.s3.amazonaws.com/bt/BDGP6.rev.1.bt2
 [bt2_bdgp6_r2]: https://genome-idx.s3.amazonaws.com/bt/BDGP6.rev.2.bt2
 [bt2_bdgp6_md5]: https://genome-idx.s3.amazonaws.com/bt/BDGP6.md5
+[bt2_bdgp6_dict]: https://genome-idx.s3.amazonaws.com/bt/BDGP6.dict
+[bt2_bdgp6_manifest]: https://genome-idx.s3.amazonaws.com/bt/BDGP6.manifest.json
 [bt2_dmela410_full]: https://genome-idx.s3.amazonaws.com/bt/Dmel_A4_1.0.zip
 [bt2_dmela410_1]: https://genome-idx.s3.amazonaws.com/bt/Dmel_A4_1.0.1.bt2
 [bt2_dmela410_2]: https://genome-idx.s3.amazonaws.com/bt/Dmel_A4_1.0.2.bt2
@@ -456,6 +518,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_dmela410_r1]: https://genome-idx.s3.amazonaws.com/bt/Dmel_A4_1.0.rev.1.bt2
 [bt2_dmela410_r2]: https://genome-idx.s3.amazonaws.com/bt/Dmel_A4_1.0.rev.2.bt2
 [bt2_dmela410_md5]: https://genome-idx.s3.amazonaws.com/bt/Dmel_A4_1.0.md5
+[bt2_dmela410_dict]: https://genome-idx.s3.amazonaws.com/bt/Dmel_A4_1.0.dict
+[bt2_dmela410_manifest]: https://genome-idx.s3.amazonaws.com/bt/Dmel_A4_1.0.manifest.json
 [bt2_wbcel235_full]: https://genome-idx.s3.amazonaws.com/bt/WBcel235.zip
 [bt2_wbcel235_1]: https://genome-idx.s3.amazonaws.com/bt/WBcel235.1.bt2
 [bt2_wbcel235_2]: https://genome-idx.s3.amazonaws.com/bt/WBcel235.2.bt2
@@ -464,6 +528,8 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_wbcel235_r1]: https://genome-idx.s3.amazonaws.com/bt/WBcel235.rev.1.bt2
 [bt2_wbcel235_r2]: https://genome-idx.s3.amazonaws.com/bt/WBcel235.rev.2.bt2
 [bt2_wbcel235_md5]: https://genome-idx.s3.amazonaws.com/bt/WBcel235.md5
+[bt2_wbcel235_dict]: https://genome-idx.s3.amazonaws.com/bt/WBcel235.dict
+[bt2_wbcel235_manifest]: https://genome-idx.s3.amazonaws.com/bt/WBcel235.manifest.json
 [bt2_r6411_full]: https://genome-idx.s3.amazonaws.com/bt/R64-1-1.zip
 [bt2_r6411_1]: https://genome-idx.s3.amazonaws.com/bt/R64-1-1.1.bt2
 [bt2_r6411_2]: https://genome-idx.s3.amazonaws.com/bt/R64-1-1.2.bt2
@@ -472,3 +538,5 @@ Corresponding S3 URLs can be obtained by removing `https://genome-idx.s3.amazona
 [bt2_r6411_r1]: https://genome-idx.s3.amazonaws.com/bt/R64-1-1.rev.1.bt2
 [bt2_r6411_r2]: https://genome-idx.s3.amazonaws.com/bt/R64-1-1.rev.2.bt2
 [bt2_r6411_md5]: https://genome-idx.s3.amazonaws.com/bt/R64-1-1.md5
+[bt2_r6411_dict]: https://genome-idx.s3.amazonaws.com/bt/R64-1-1.dict
+[bt2_r6411_manifest]: https://genome-idx.s3.amazonaws.com/bt/R64-1-1.manifest.json

--- a/docs/check_site_links.py
+++ b/docs/check_site_links.py
@@ -26,6 +26,7 @@ Usage:
   cd docs && python3 check_site_links.py
   python3 docs/check_site_links.py --root docs
   python3 check_site_links.py --verbose --workers 12
+  python3 docs/check_site_links.py --root docs --only bowtie.md --check-s3
 """
 
 from __future__ import annotations
@@ -395,6 +396,15 @@ def main() -> int:
         help="Verify ftp:// links (off by default; servers often rate-limit)",
     )
     ap.add_argument(
+        "--only",
+        nargs="+",
+        metavar="REL_PATH",
+        help=(
+            "Only scan these paths relative to --root (e.g. bowtie.md). "
+            "Useful for targeted checks after a partial doc or S3 update."
+        ),
+    )
+    ap.add_argument(
         "--request-delay",
         type=float,
         default=0.0,
@@ -412,6 +422,14 @@ def main() -> int:
     files = find_markdown_files(docs_root, args.include_skills) + find_layout_files(
         docs_root
     )
+    if args.only:
+        wanted = {(docs_root / rel).resolve() for rel in args.only}
+        files = [f for f in files if f.resolve() in wanted]
+        found_resolved = {f.resolve() for f in files}
+        for w in sorted(wanted):
+            if w not in found_resolved:
+                print(f"Error: --only path not found under root: {w}", file=sys.stderr)
+                return 2
     if not files:
         print("No source files found.", file=sys.stderr)
         return 0

--- a/xfer/bt/shortname_map.csv
+++ b/xfer/bt/shortname_map.csv
@@ -1,42 +1,42 @@
-grch38_noalt,GRCh38_noalt_as,Human,H. sapiens,GRCh38 no-alt analysis set,NCBI
-grch38_noalt_decoy,GRCh38_noalt_decoy_as,Human,H. sapiens,GRCh38 no-alt +decoy set,NCBI
-grch38_1kgmaj,grch38_1kgmaj,Human,H. sapiens,GRCh38 + major SNVs,NCBI+1KG<sup>1</sup>
-grch37,GRCh37,Human,H. sapiens,GRCh37,NCBI
-ash1,Ash1v1.7,Human,H. sapiens,Ash1v1.7,JHU <sup>2</sup>
-ash1_2,Ash1_v2.0,Human,H. sapiens,Ash1v2.0,JHU <sup>2</sup>
-t2tplusy,chm13.draft_v1.0_plusY,Human,H. sapiens,CHM13plusY,T2T <sup>3</sup>
+grch38_noalt,GRCh38_noalt_as,Human,H. sapiens,GRCh38 no-alt analysis set,NCBI,bt2,dict;manifest
+grch38_noalt_decoy,GRCh38_noalt_decoy_as,Human,H. sapiens,GRCh38 no-alt +decoy set,NCBI,bt2,dict;manifest
+grch38_1kgmaj,grch38_1kgmaj,Human,H. sapiens,GRCh38 + major SNVs,NCBI+1KG<sup>1</sup>,bt2,dict;manifest
+grch37,GRCh37,Human,H. sapiens,GRCh37,NCBI,bt2,dict;manifest
+ash1,Ash1v1.7,Human,H. sapiens,Ash1v1.7,JHU <sup>2</sup>,bt2,dict;manifest
+ash1_2,Ash1_v2.0,Human,H. sapiens,Ash1v2.0,JHU <sup>2</sup>,bt2,dict;manifest
+t2tplusy,chm13.draft_v1.0_plusY,Human,H. sapiens,CHM13plusY,T2T <sup>3</sup>,bt2,dict;manifest
 hs1,hs1,Human,H. sapiens,hs1 / T2T-CHM13v2.0,UCSC,bt2,dict;manifest
-hg19,hg19,Human,H. sapiens,hg19,UCSC
-hg18,hg18,Human,H. sapiens,hg18,UCSC
-grcm38,GRCm38,Mouse,M. Musculus,GRCm38,NCBI
-grcm39,GRCm39,Mouse,M. Musculus,GRCm39,NCBI
-mm10,mm10,Mouse,M. Musculus,mm10,UCSC
-mm9,mm9,Mouse,M. Musculus,mm9,UCSC
-clintptr2,Clint_PTRv2,Chimpanzee,P. troglodytes,Clint_PTRv2,NCBI
-chimp214,CHIMP2.1.4,Chimpanzee,P. troglodytes,CHIMP2.1.4,Ensembl
-mmul10,Mmul_10,Rhesus macaque,M. mulatta,MMul_10,Ensembl
+hg19,hg19,Human,H. sapiens,hg19,UCSC,bt2,dict;manifest
+hg18,hg18,Human,H. sapiens,hg18,UCSC,bt2,dict;manifest
+grcm38,GRCm38,Mouse,M. Musculus,GRCm38,NCBI,bt2,dict;manifest
+grcm39,GRCm39,Mouse,M. Musculus,GRCm39,NCBI,bt2,dict;manifest
+mm10,mm10,Mouse,M. Musculus,mm10,UCSC,bt2,dict;manifest
+mm9,mm9,Mouse,M. Musculus,mm9,UCSC,bt2,dict;manifest
+clintptr2,Clint_PTRv2,Chimpanzee,P. troglodytes,Clint_PTRv2,NCBI,bt2,dict;manifest
+chimp214,CHIMP2.1.4,Chimpanzee,P. troglodytes,CHIMP2.1.4,Ensembl,bt2,dict;manifest
+mmul10,Mmul_10,Rhesus macaque,M. mulatta,MMul_10,Ensembl,bt2,dict;manifest
 arsucd20,ARS-UCD2.0,Cow,B. taurus,ARS-UCD2.0,NCBI RefSeq,bt2,dict;manifest
-arsucd12,ARS-UCD1.2,Cow,B. taurus,ARS-UCD1.2,NCBI
-sscorfa111,Sscrofa11.1,Pig,S. scrofa,Sscrofa11.1,NCBI
+arsucd12,ARS-UCD1.2,Cow,B. taurus,ARS-UCD1.2,NCBI,bt2,dict;manifest
+sscorfa111,Sscrofa11.1,Pig,S. scrofa,Sscrofa11.1,NCBI,bt2,dict;manifest
 roscfam10,ROS_Cfam_1.0,Dog,C. familiaris,ROS_Cfam_1.0,NCBI RefSeq,bt2,dict;manifest
-canfam31,CanFam3.1,Dog,C. familiaris,CanFam3.1,Ensembl
-canfam4,canfam4,Dog,C. familiaris,CanFam4,NCBI
+canfam31,CanFam3.1,Dog,C. familiaris,CanFam3.1,Ensembl,bt2,dict;manifest
+canfam4,canfam4,Dog,C. familiaris,CanFam4,NCBI,bt2,dict;manifest
 grcr8,GRCr8,Rat,R. norvegicus,GRCr8,NCBI RefSeq,bt2,dict;manifest
-rn4,rn4,Rat,R. norvegicus,rn4,UCSC
-rnor60,Rnor_6.0,Rat,R. norvegicus,Rnor6.0,NCBI
+rn4,rn4,Rat,R. norvegicus,rn4,UCSC,bt2,dict;manifest
+rnor60,Rnor_6.0,Rat,R. norvegicus,Rnor6.0,NCBI,bt2,dict;manifest
 grcg7b,bGalGal1.mat.broiler.GRCg7b,Chicken,G. gallus,bGalGal1.mat.broiler.GRCg7b,NCBI RefSeq,bt2,dict;manifest
-grcg6a,GRCg6a,Chicken,G. gallus,GRCg6a,NCBI
-galgal4,Galgal4,Chicken,G. gallus,Galgal4,Ensembl
-grcz11,GRCz11,Zebrafish,D. rerio,GRCz11,NCBI
-grcz10,GRCz10,Zebrafish,D. rerio,GRCz10,NCBI
-agpv4,AGPv4,Corn,Z. mays,AGPv4,Ensembl
-b73_refgen_v5,Zm-B73-REFERENCE-NAM-5.0,Corn,Z. mays,B73 RefGenV5,NCBI
+grcg6a,GRCg6a,Chicken,G. gallus,GRCg6a,NCBI,bt2,dict;manifest
+galgal4,Galgal4,Chicken,G. gallus,Galgal4,Ensembl,bt2,dict;manifest
+grcz11,GRCz11,Zebrafish,D. rerio,GRCz11,NCBI,bt2,dict;manifest
+grcz10,GRCz10,Zebrafish,D. rerio,GRCz10,NCBI,bt2,dict;manifest
+agpv4,AGPv4,Corn,Z. mays,AGPv4,Ensembl,bt2,dict;manifest
+b73_refgen_v5,Zm-B73-REFERENCE-NAM-5.0,Corn,Z. mays,B73 RefGenV5,NCBI,bt2,dict;manifest
 iwgsc,IWGSC,Wheat,T. aestivum,IWGSC,Ensembl Plants,bt2l,dict;manifest
 morexv3,MorexV3_pseudomolecules_assembly,Barley,H. vulgare,MorexV3_pseudomolecules_assembly,Ensembl Plants,bt2l,dict;manifest
 irgsp10,IRGSP-1.0,Oryza sativa (rice),O. sativa,IRGSP-1.0,Ensembl Plants,bt2,dict;manifest
-build4,Build_4.0,Oryza sativa (rice),O. sativa,Build_4.0,NCBI
-tair10,TAIR10,Arabidopsis thaliana,A. thaliana,TAIR10,Ensembl
-bdgp6,BDGP6,Fruitfly,D. melanogaster,BDGP6,Ensembl
-dmela410,Dmel_A4_1.0,Fruitfly,D. melanogaster,Dmel A4 1.0,NCBI
-wbcel235,WBcel235,C. elegans,C. elegans,WBcel235,Ensembl
-r6411,R64-1-1,Yeast,S. cerevisiae,R64-1-1,Ensembl
+build4,Build_4.0,Oryza sativa (rice),O. sativa,Build_4.0,NCBI,bt2,dict;manifest
+tair10,TAIR10,Arabidopsis thaliana,A. thaliana,TAIR10,Ensembl,bt2,dict;manifest
+bdgp6,BDGP6,Fruitfly,D. melanogaster,BDGP6,Ensembl,bt2,dict;manifest
+dmela410,Dmel_A4_1.0,Fruitfly,D. melanogaster,Dmel A4 1.0,NCBI,bt2,dict;manifest
+wbcel235,WBcel235,C. elegans,C. elegans,WBcel235,Ensembl,bt2,dict;manifest
+r6411,R64-1-1,Yeast,S. cerevisiae,R64-1-1,Ensembl,bt2,dict;manifest


### PR DESCRIPTION
## Summary
- Add metadata-only backfill workflow for legacy Bowtie indexes on `s3://genome-idx/bt/` (`.dict`, `.manifest.json`, `.build.txt`, updated `.zip`/`.md5`) without re-running `bowtie2-build`.
- Extend `build_indexes.bash` with `--metadata-only`, `--backfill`, and `--from-s3-prefix`; add `audit_s3.py`, `legacy_targets.tsv`, and pilot/full/resume runner scripts.
- Update `docs/bowtie.md` and `xfer/bt/shortname_map.csv` so all 42 assemblies list Metadata links for archive md5, `.dict`, and `.manifest.json` (S3 sidecars are already uploaded).

Merging this PR updates the GitHub Pages Bowtie catalog from 8 assemblies with metadata links to all 42.

## Test plan
- [x] `AWS_PROFILE=index-zone-s3 python3 build/bowtie/audit_s3.py --require-metadata --strict` (42/42 OK)
- [x] Spot-check S3 HTTPS HEAD for legacy indexes (e.g. `GRCh37.dict`, `Mmul_10.manifest.json` → 200)
- [ ] After merge: confirm [Bowtie page](https://benlangmead.github.io/aws-indexes/bowtie.html) shows `.dict` / manifest links for legacy rows (e.g. GRCh37, MMul_10)
- [ ] `cd docs && python3 check_site_links.py --only bowtie.md --check-s3` (S3 metadata URLs; external source URLs may still fail independently)


Made with [Cursor](https://cursor.com)