### PR TITLE
docs/mumemto: fix mid-table scroll artifact on wide tables

### DIFF
--- a/docs/mumemto.md
+++ b/docs/mumemto.md
@@ -1,3 +1,17 @@
+<style>
+/* These tables have long, prose descriptions.  On wider viewports, wrap the
+   columns to fit the content area instead of forcing a very wide horizontal
+   scroll (that scroll left an edge-fade rendering artifact mid-table).  On
+   small screens they fall back to the site-wide horizontal-scroll behavior. */
+@media (min-width: 721px) {
+  .table-scroll table { width: 100%; min-width: 0; }
+  .table-scroll th,
+  .table-scroll td { white-space: normal; overflow-wrap: anywhere; vertical-align: top; }
+  .table-scroll th:first-child,
+  .table-scroll td:first-child { white-space: nowrap; }
+}
+</style>
+
 # Mumemto and Shredtools HPRC indexes
 
 Mumemto ([GitHub repo](https://github.com/vikshiv/mumemto)) is an efficient multi-MUM finder for large pangenomes.  Multi-MUMs have a variety of uses, including forming a pangenome coordinate system, visualizing synteny, and serving as a basis for multiple genome alignment.


### PR DESCRIPTION
Follow-up to #81 (which is already merged). That PR added the Mumemto page; this one fixes a rendering artifact reported on it.

## Problem
The tables use `width: max-content`, so the long prose descriptions make them ~2180px wide and always horizontally scrollable. The `.table-scroll` edge-fade overlays are absolutely positioned **inside** the scroller, so on horizontal scroll they travel with the content and paint as a ghost box **mid-table** instead of hugging the visible edge.

## Fix
A page-scoped `<style>` block in `docs/mumemto.md`:
- **>720px:** table columns wrap to fit the content area (file-name column kept on one line) → no horizontal scroll → no fade artifact (and it reads better).
- **≤720px:** falls back to the site-wide horizontal-scroll behavior, so mobile is unchanged.

Scoped to this page only; shared CSS/JS is untouched, so no risk to other pages.

## Verification
- Reproduced the artifact and confirmed its removal in a browser using the real `styles.css` + `datatable-wrap.js`.
- Rendered the actual `mumemto.md`: all three tables report `scrollWidth == clientWidth` (no overflow) at 834px and 1100px.
- Confirmed kramdown passes the `<style>` block through un-escaped and renders all 3 tables.
- Confirmed mobile (375px) reverts to normal scrolling.

Note: the underlying overlay bug is latent site-wide (any table wide enough to scroll can show it). This PR intentionally stays scoped to the Mumemto page; a shared-CSS fix could follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)